### PR TITLE
Dependency upgrades and other maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ dirs = "6.0.0"
 elf = "0.7.4"
 indicatif = "0.17.8"
 itertools = "0.14.0"
-fs-err = { version = "3.0.0", features = ["tokio"] }
+fs-err = { version = "3.1.0", features = ["tokio"] }
 futures-util = "0.3.31"
 glob = "0.3.1"
 hex = "0.4.3"

--- a/boulder/src/package/emit.rs
+++ b/boulder/src/package/emit.rs
@@ -197,7 +197,7 @@ fn emit_package(paths: &Paths, package: &Package<'_>) -> Result<(), Error> {
     if !files.is_empty() {
         // Temp file for building content payload
         let temp_content_path = format!("/tmp/{}.tmp", &filename);
-        let mut temp_content = fs::OpenOptions::new()
+        let mut temp_content = File::options()
             .read(true)
             .append(true)
             .create(true)

--- a/moss/src/cli/extract.rs
+++ b/moss/src/cli/extract.rs
@@ -56,7 +56,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
         }
 
         if let Some(content) = content {
-            let content_file = fs::OpenOptions::new()
+            let content_file = File::options()
                 .read(true)
                 .write(true)
                 .create(true)

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -135,7 +135,7 @@ impl Download {
         unpacking_in_progress: UnpackingInProgress,
         on_progress: impl Fn(Progress) + Send + 'static,
     ) -> Result<UnpackedAsset, Error> {
-        use fs_err::{self as fs, File, OpenOptions};
+        use fs_err::{self as fs, File};
         use std::io::{self, Read, Seek, SeekFrom, Write};
 
         struct ProgressWriter<'a, W> {
@@ -201,7 +201,7 @@ impl Download {
             .find_map(PayloadKind::content)
             .ok_or(Error::MissingContent)?;
 
-        let content_file = OpenOptions::new()
+        let content_file = File::options()
             .read(true)
             .write(true)
             .create(true)

--- a/moss/src/installation/lockfile.rs
+++ b/moss/src/installation/lockfile.rs
@@ -10,7 +10,7 @@ use std::{
     sync::Arc,
 };
 
-use fs_err::{self as fs, File};
+use fs_err::File;
 use nix::fcntl::{flock, FlockArg};
 use thiserror::Error;
 
@@ -31,11 +31,7 @@ pub struct Lock(Arc<File>);
 pub fn acquire(path: impl Into<PathBuf>, block_msg: impl fmt::Display) -> Result<Lock, Error> {
     let path = path.into();
 
-    let file = fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(path)?;
+    let file = File::options().create(true).write(true).truncate(false).open(path)?;
 
     match flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
         Ok(_) => {}

--- a/moss/src/signal.rs
+++ b/moss/src/signal.rs
@@ -15,11 +15,13 @@ pub fn ignore(signals: impl IntoIterator<Item = Signal>) -> Result<Guard, Error>
     Ok(Guard(
         signals
             .into_iter()
-            .map(|signal| unsafe {
-                let action = sigaction(
-                    signal,
-                    &SigAction::new(SigHandler::SigIgn, SaFlags::empty(), SigSet::empty()),
-                )
+            .map(|signal| {
+                let action = unsafe {
+                    sigaction(
+                        signal,
+                        &SigAction::new(SigHandler::SigIgn, SaFlags::empty(), SigSet::empty()),
+                    )
+                }
                 .map_err(Error::Ignore)?;
 
                 Ok(PrevHandler { signal, action })


### PR DESCRIPTION
I have not tested this (nor am I certain how to best do that). Much more straight-forward than my failed rustix PRs though.

I'm happy with rebasing this over time if keeping up with the ecosystem is not currently a priority. (I just like doing this sort of work and had fs-err `File::options` on my todo > got that merged today > I checked out where it would be useful > found `OpenOptions` usage in this repo > found more dependencies that were not at the latest version > found an unnecessarily large unsafe block while upgrading nix)