### PR TITLE
boulder/draft: Add initial ruby support to boulder new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "blsforme"
 version = "0.1.0"
-source = "git+https://github.com/serpent-os/blsforme.git?rev=3cb315d6e9b4f2168927bded8b326b55c92f0e84#3cb315d6e9b4f2168927bded8b326b55c92f0e84"
+source = "git+https://github.com/AerynOS/blsforme.git?rev=3cb315d6e9b4f2168927bded8b326b55c92f0e84#3cb315d6e9b4f2168927bded8b326b55c92f0e84"
 dependencies = [
  "blake3",
  "gpt",
@@ -2689,7 +2689,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "superblock"
 version = "0.1.0"
-source = "git+https://github.com/serpent-os/blsforme.git?rev=3cb315d6e9b4f2168927bded8b326b55c92f0e84#3cb315d6e9b4f2168927bded8b326b55c92f0e84"
+source = "git+https://github.com/AerynOS/blsforme.git?rev=3cb315d6e9b4f2168927bded8b326b55c92f0e84#3cb315d6e9b4f2168927bded8b326b55c92f0e84"
 dependencies = [
  "log",
  "thiserror 2.0.3",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "topology"
 version = "0.1.0"
-source = "git+https://github.com/serpent-os/blsforme.git?rev=3cb315d6e9b4f2168927bded8b326b55c92f0e84#3cb315d6e9b4f2168927bded8b326b55c92f0e84"
+source = "git+https://github.com/AerynOS/blsforme.git?rev=3cb315d6e9b4f2168927bded8b326b55c92f0e84#3cb315d6e9b4f2168927bded8b326b55c92f0e84"
 dependencies = [
  "gpt",
  "log",

--- a/boulder/src/draft/build.rs
+++ b/boulder/src/draft/build.rs
@@ -13,6 +13,7 @@ mod cargo;
 mod cmake;
 mod meson;
 mod python;
+mod ruby;
 
 pub type Error = Box<dyn std::error::Error>;
 
@@ -26,6 +27,8 @@ pub enum System {
     Meson,
     PythonPep517,
     PythonSetupTools,
+    RubyGem,
+    RubyTarball,
 }
 
 impl System {
@@ -36,6 +39,8 @@ impl System {
         Self::Meson,
         Self::PythonPep517,
         Self::PythonSetupTools,
+        Self::RubyGem,
+        Self::RubyTarball,
     ];
 
     pub fn environment(&self) -> Option<&'static str> {
@@ -46,6 +51,8 @@ impl System {
             System::Meson => None,
             System::PythonPep517 => None,
             System::PythonSetupTools => None,
+            System::RubyGem => None,
+            System::RubyTarball => None,
         }
     }
 
@@ -57,6 +64,8 @@ impl System {
             System::Meson => meson::phases(),
             System::PythonPep517 => python::pep517::phases(),
             System::PythonSetupTools => python::setup_tools::phases(),
+            System::RubyGem => ruby::gemfile::phases(),
+            System::RubyTarball => ruby::tarball::phases(),
         }
     }
 
@@ -76,6 +85,8 @@ impl System {
             System::Meson => meson::process(state, file),
             System::PythonPep517 => python::pep517::process(state, file),
             System::PythonSetupTools => python::setup_tools::process(state, file),
+            System::RubyGem => ruby::gemfile::process(state, file),
+            System::RubyTarball => ruby::tarball::process(state, file),
         }
     }
 }

--- a/boulder/src/draft/build/ruby.rs
+++ b/boulder/src/draft/build/ruby.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright © 2020-2025 Serpent OS Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+// filename.gem
+pub mod gemfile {
+    use crate::draft::build::{Error, Phases, State};
+    use crate::draft::File;
+
+    pub fn phases() -> Phases {
+        Phases {
+            setup: None,
+            build: None,
+            install: Some("%gem_install"),
+            check: None,
+        }
+    }
+
+    pub fn process(state: &mut State<'_>, file: &File<'_>) -> Result<(), Error> {
+        match file.file_name() {
+            "checksums.yaml.gz" if file.depth() == 0 => state.increment_confidence(50),
+            "data.tar.gz" if file.depth() == 0 => state.increment_confidence(80),
+            "metadata.gz" if file.depth() == 0 => state.increment_confidence(100),
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+// A normal tarball
+pub mod tarball {
+    use crate::draft::build::{Error, Phases, State};
+    use crate::draft::File;
+
+    pub fn phases() -> Phases {
+        Phases {
+            setup: None,
+            build: Some("%gem_build"),
+            install: Some("%gem_install"),
+            check: None,
+        }
+    }
+
+    pub fn process(state: &mut State<'_>, file: &File<'_>) -> Result<(), Error> {
+        match file.file_name() {
+            _ if file.depth() == 0 && file.file_name().ends_with(".gemspec") => {
+                state.increment_confidence(100);
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Split ruby support into:
- Ruby .gem files which only need a `%gem_install` and contain a layout
  containing several tarballs
- Normal tarballs containing a .gemspec file, which'll need a `%gem_build`
  and `%gem_install` macros