### PR TITLE
boulder/draft/metadata: Match underscores in basic first capture group

### DIFF
--- a/boulder/src/draft/metadata/basic.rs
+++ b/boulder/src/draft/metadata/basic.rs
@@ -12,7 +12,7 @@ use super::Source;
 pub fn source(upstream: &Url) -> Option<Source> {
     let filename = util::uri_file_name(upstream);
 
-    let regex = Regex::new(r"^([a-zA-Z0-9-]+)-([a-zA-Z0-9._-]+)\.(zip|tar|sh|bin\.*)").ok()?;
+    let regex = Regex::new(r"^([a-zA-Z0-9_-]+)-([a-zA-Z0-9._-]+)\.(zip|tar|sh|bin\.*)").ok()?;
     let captures = regex.captures(filename)?;
 
     let name = captures.get(1)?.as_str().to_owned();


### PR DESCRIPTION
A filename such as `drm_info-v2.7.0.tar.gz` will now match properly.

Part of #414.