### PR TITLE
boulder: Adapt GNU toolchain to libstdc++ split

### DIFF
--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -202,7 +202,7 @@ const BASE_PACKAGES: &[&str] = &[
 const BASE32_PACKAGES: &[&str] = &["glibc-32bit-devel"];
 
 const GNU_PACKAGES: &[&str] = &["binutils", "gcc", "g++"];
-const GNU32_PACKAGES: &[&str] = &["gcc-32bit", "g++-32bit"];
+const GNU32_PACKAGES: &[&str] = &["gcc-32bit", "libstdc++-32bit-devel"];
 
 const LLVM_PACKAGES: &[&str] = &["clang"];
 const LLVM32_PACKAGES: &[&str] = &["clang-32bit", "libcxx-32bit-devel"];


### PR DESCRIPTION
Merge after AerynOS/recipes#683