### PR TITLE
boulder/macros: Update polly flags

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -516,8 +516,8 @@ flags               :
     # Enable LLVM polly optimisations (OFF)
     - polly:
         llvm:
-            c     : "-Xclang -mllvm -Xclang -polly -Xclang -mllvm -Xclang -polly-vectorizer=stripmine"
-            cxx   : "-Xclang -mllvm -Xclang -polly -Xclang -mllvm -Xclang -polly-vectorizer=stripmine"
+            c     : "-fplugin=LLVMPolly.so -fpass-plugin=LLVMPolly.so -Xclang -mllvm -Xclang -polly -Xclang -mllvm -Xclang -polly-vectorizer=stripmine"
+            cxx   : "-fplugin=LLVMPolly.so -fpass-plugin=LLVMPolly.so -Xclang -mllvm -Xclang -polly -Xclang -mllvm -Xclang -polly-vectorizer=stripmine"
             d     : "-polly -polly-vectorizer=stripmine"
 
     # Toggle options you want to use with llvm-bolt (OFF)


### PR DESCRIPTION
Now that Polly is no longer linked into libLLVM/clang directly we need to load it as a plugin explicitly in order for it to be used.

Don't ask how long this took me to figure out.

Merge after AerynOS/recipes#762