### PR TITLE
boulder/moss: implement `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1826,15 @@ dependencies = [
  "charset",
  "data-encoding",
  "quoted_printable",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1926,6 +1950,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tools_buildinfo",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "triggers",
  "tui",
  "url",
@@ -1966,6 +1993,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -2036,6 +2073,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2346,8 +2389,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2358,8 +2410,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2663,6 +2721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,6 +2977,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,6 +3197,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,6 +3226,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3250,6 +3382,12 @@ checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -10,6 +10,9 @@ container = { path = "../crates/container" }
 dag = { path = "../crates/dag" }
 tools_buildinfo = { path = "../crates/tools_buildinfo" }
 stone = { path = "../crates/stone" }
+tracing = "0.1.41"
+tracing-appender = "0.2.3"
+tracing-subscriber = { version = "0.3.19", features = ["json", "serde", "env-filter"] }
 triggers = { path = "../crates/triggers" }
 tui = { path = "../crates/tui" }
 vfs = { path = "../crates/vfs" }

--- a/moss/src/cli/boot.rs
+++ b/moss/src/cli/boot.rs
@@ -32,21 +32,21 @@ pub fn handle(_args: &ArgMatches, installation: Installation) -> Result<(), Erro
     let manager = blsforme::Manager::new(&config)?;
     match manager.boot_environment().firmware {
         blsforme::Firmware::UEFI => {
-            println!("ESP            : {:?}", manager.boot_environment().esp());
-            println!("XBOOTLDR       : {:?}", manager.boot_environment().xbootldr());
+            tracing::info!("ESP            : {:?}", manager.boot_environment().esp());
+            tracing::info!("XBOOTLDR       : {:?}", manager.boot_environment().xbootldr());
             if is_native {
                 if let Ok(bootloader) = systemd_boot::interface::BootLoaderInterface::new(&config.vfs) {
                     let v = bootloader.get_ucs2_string(systemd_boot::interface::VariableName::Info)?;
-                    println!("Bootloader     : {v}");
+                    tracing::info!("Bootloader     : {v}");
                 }
             }
         }
         blsforme::Firmware::BIOS => {
-            println!("BOOT           : {:?}", manager.boot_environment().boot_partition());
+            tracing::info!("BOOT           : {:?}", manager.boot_environment().boot_partition());
         }
     }
 
-    println!("Global cmdline : {:?}", manager.cmdline());
+    tracing::info!("Global cmdline : {:?}", manager.cmdline());
 
     Ok(())
 }

--- a/moss/src/cli/extract.rs
+++ b/moss/src/cli/extract.rs
@@ -37,7 +37,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
     let content_store = PathBuf::from(".stoneStore");
 
     for path in paths {
-        println!("Extract: {path:?}");
+        tracing::info!("Extract: {path:?}");
 
         let rdr = File::open(path).map_err(Error::IO)?;
         let mut reader = stone::read(rdr).map_err(Error::Format)?;

--- a/moss/src/cli/index.rs
+++ b/moss/src/cli/index.rs
@@ -31,7 +31,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
 
     let stone_files = enumerate_stone_files(&dir)?;
 
-    println!("Indexing {} files\n", stone_files.len());
+    tracing::info!("Indexing {} files\n", stone_files.len());
 
     let multi_progress = MultiProgress::new();
 
@@ -79,7 +79,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
 
     multi_progress.clear()?;
 
-    println!("\nIndex file written to {:?}", dir.join("stone.index").display());
+    tracing::info!("\nIndex file written to {:?}", dir.join("stone.index").display());
 
     Ok(())
 }
@@ -143,7 +143,7 @@ fn get_meta(
 
     progress.finish();
     multi_progress.remove(&progress);
-    multi_progress.suspend(|| println!("{} {}", "Indexed".green(), relative_path.bold()));
+    multi_progress.suspend(|| tracing::info!("{} {}", "Indexed".green(), relative_path.bold()));
     total_progress.inc(1);
 
     Ok(meta)

--- a/moss/src/cli/list.rs
+++ b/moss/src/cli/list.rs
@@ -137,27 +137,27 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         } else {
             item.name.dim()
         };
-        print!("{name} {:width$} ", " ");
 
-        let print_revision = |rev: Revision, is_sync| {
+        let print_revision = |rev: Revision, is_sync| -> String {
             let version = if is_sync {
                 rev.version.green()
             } else {
                 rev.version.magenta()
             };
-            print!("{version}-{}", rev.release.dim());
+            format!("{version}-{}", rev.release.dim())
         };
 
         // Print revision
-        print_revision(item.revision, false);
+        let local = print_revision(item.revision, false);
 
         // Print sync version
-        if let Some(sync) = item.sync {
-            print!(" => ");
-            print_revision(sync, true);
-        }
+        let sync = if let Some(sync) = item.sync {
+            format!(" => {}", print_revision(sync, true))
+        } else {
+            String::new() // Ensures `sync` is always a `String`
+        };
 
-        println!(" - {}", item.summary);
+        tracing::info!("{name} {:width$} {local}{sync} - {}", " ", item.summary)
     }
 
     Ok(())

--- a/moss/src/cli/repo.rs
+++ b/moss/src/cli/repo.rs
@@ -144,7 +144,7 @@ fn add(
 
     runtime::block_on(manager.refresh(&id))?;
 
-    println!("{id} added");
+    tracing::info!("{id} added");
 
     Ok(())
 }
@@ -155,7 +155,7 @@ fn list(installation: Installation, config: config::Manager) -> Result<(), Error
 
     let configured_repos = manager.list();
     if configured_repos.len() == 0 {
-        println!("No repositories have been configured yet");
+        tracing::info!("No repositories have been configured yet");
         return Ok(());
     }
 
@@ -166,7 +166,7 @@ fn list(installation: Installation, config: config::Manager) -> Result<(), Error
             String::new()
         };
 
-        println!(" - {id} = {} [{}]{disabled}", repo.uri, repo.priority);
+        tracing::info!(" - {id} = {} [{}]{disabled}", repo.uri, repo.priority);
     }
 
     Ok(())
@@ -194,17 +194,17 @@ fn remove(installation: Installation, config: config::Manager, repo: String) -> 
 
     match manager.remove(id.clone())? {
         repository::manager::Removal::NotFound => {
-            println!("{id} not found");
+            tracing::info!("{id} not found");
             process::exit(1);
         }
         repository::manager::Removal::ConfigDeleted(false) => {
-            println!(
+            tracing::info!(
                 "{id} configuration must be manually deleted since it doesn't exist in it's own configuration file"
             );
             process::exit(1);
         }
         repository::manager::Removal::ConfigDeleted(true) => {
-            println!("{id} removed");
+            tracing::info!("{id} removed");
         }
     }
 
@@ -217,7 +217,7 @@ fn enable(installation: Installation, config: config::Manager, repo: String) -> 
 
     runtime::block_on(manager.enable(&id))?;
 
-    println!("{id} enabled");
+    tracing::info!("{id} enabled");
 
     Ok(())
 }
@@ -228,7 +228,7 @@ fn disable(installation: Installation, config: config::Manager, repo: String) ->
 
     runtime::block_on(manager.disable(&id))?;
 
-    println!("{id} disabled");
+    tracing::info!("{id} disabled");
 
     Ok(())
 }

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -59,6 +59,14 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         return Ok(());
     }
 
+    tracing::trace!("search for {}", keyword);
+    for package in output.iter() {
+        tracing::trace!(
+            package_type = "synced",
+            name = %package.name,
+            summary = %package.summary
+        );
+    }
     print_columns(&output, 1);
 
     Ok(())

--- a/moss/src/cli/state.rs
+++ b/moss/src/cli/state.rs
@@ -104,7 +104,7 @@ pub fn activate(args: &ArgMatches, installation: Installation) -> Result<(), Err
     let client = Client::new(environment::NAME, installation)?;
     let old_id = client.activate_state(new_id.into(), skip_triggers)?;
 
-    println!(
+    tracing::info!(
         "State {} activated {}",
         new_id.to_string().bold(),
         format!("({old_id} archived)").dim()
@@ -149,16 +149,16 @@ fn print_state(state: state::State) {
     let local_time = state.created.with_timezone(&Local);
     let formatted_time = local_time.format("%Y-%m-%d %H:%M:%S %Z");
 
-    println!(
+    tracing::info!(
         "State #{} - {}",
         state.id.to_string().bold(),
         state.summary.unwrap_or_else(|| String::from("system transaction"))
     );
-    println!("{} {formatted_time}", "Created:".bold());
+    tracing::info!("{} {formatted_time}", "Created:".bold());
     if let Some(desc) = &state.description {
-        println!("{} {desc}", "Description:".bold());
+        tracing::info!("{} {desc}", "Description:".bold());
     }
-    println!("{} {}", "Packages:".bold(), state.selections.len());
+    tracing::info!("{} {}", "Packages:".bold(), state.selections.len());
     println!();
 }
 

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -82,18 +82,36 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         .collect::<Vec<_>>();
 
     if synced.is_empty() && removed.is_empty() {
-        println!("No packages to sync");
+        tracing::info!("No packages to sync");
         return Ok(());
     }
 
     if !synced.is_empty() {
-        println!("The following packages will be sync'd: ");
+        tracing::info!("The following packages will be sync'd: ");
+        for package in synced.iter() {
+            tracing::trace!(
+                type = "package",
+                action = "sync",
+                name = %package.meta.name,
+                version = %format!("{}-{}", package.meta.version_identifier, package.meta.source_release),
+                "Package update event"
+            );
+        }
         println!();
         autoprint_columns(synced.as_slice());
         println!();
     }
     if !removed.is_empty() {
-        println!("The following orphaned packages will be removed: ");
+        tracing::info!("The following orphaned packages will be removed: ");
+        for package in removed.iter() {
+            tracing::trace!(
+                type = "package",
+                action = "remove",
+                name = %package.meta.name,
+                version = %format!("{}-{}", package.meta.version_identifier, package.meta.source_release),
+                "Package update event"
+            );
+        }
         println!();
         autoprint_columns(removed.as_slice());
         println!();

--- a/moss/src/cli/version.rs
+++ b/moss/src/cli/version.rs
@@ -22,10 +22,10 @@ pub fn handle(args: &ArgMatches) {
 
 /// Print program version
 pub fn print() {
-    println!("moss {}", tools_buildinfo::get_simple_version());
+    tracing::info!("moss {}", tools_buildinfo::get_simple_version());
 }
 
 /// Print additional build information
 pub fn print_full() {
-    println!("moss {}", tools_buildinfo::get_full_version());
+    tracing::info!("moss {}", tools_buildinfo::get_full_version());
 }

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -64,7 +64,16 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
             .collect::<Vec<_>>();
 
         if !installed.is_empty() {
-            println!("The following package(s) are already installed:");
+            tracing::info!("The following package(s) are already installed:");
+            for package in installed.iter() {
+                tracing::trace!(
+                    type = "package",
+                    action = "none",
+                    name = %package.meta.name,
+                    version = %format!("{}-{}", package.meta.version_identifier, package.meta.source_release),
+                    "Package update event"
+                );
+            }
             println!();
             autoprint_columns(&installed);
         }
@@ -75,7 +84,16 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
     // Testing panic for hyperfine benchmarking purposes (build flag tuning)
     // panic!();
 
-    println!("The following package(s) will be installed:");
+    tracing::info!("The following package(s) will be installed:");
+    for package in missing.iter() {
+        tracing::trace!(
+            type = "package",
+            action = "install",
+            name = %package.meta.name,
+            version = %format!("{}-{}", package.meta.version_identifier, package.meta.source_release),
+            "Package update event"
+        );
+    }
     println!();
     autoprint_columns(&missing);
     println!();

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -530,7 +530,7 @@ impl Client {
 
                     // Write installed line
                     multi_progress
-                        .suspend(|| println!("{} {}{cached_tag}", "Installed".green(), package_name.clone().bold()));
+                        .suspend(|| tracing::warn!("{} {}{cached_tag}", "Installed".green(), package_name.clone().bold()));
 
                     // Inc total progress by 1
                     total_progress.inc(1);
@@ -662,7 +662,7 @@ impl Client {
         let elapsed = now.elapsed();
         let num_entries = stats.num_entries();
 
-        println!(
+        tracing::info!(
             "\n{} entries blitted in {} {}",
             num_entries.to_string().bold(),
             format!("{:.2}s", elapsed.as_secs_f32()).bold(),

--- a/moss/src/client/postblit.rs
+++ b/moss/src/client/postblit.rs
@@ -202,12 +202,12 @@ fn execute_trigger_directly(trigger: &CompiledHandler) -> Result<(), Error> {
                     let stdout = String::from_utf8_lossy(&cmd.stdout);
                     let stderr = String::from_utf8_lossy(&cmd.stderr);
 
-                    eprintln!("Trigger exited with non-zero status code: {run} {args:?}");
-                    eprintln!("   Stdout: {stdout}");
-                    eprintln!("   Stderr: {stderr}");
+                    tracing::warn!("Trigger exited with non-zero status code: {run} {args:?}");
+                    tracing::warn!("   Stdout: {stdout}");
+                    tracing::warn!("   Stderr: {stderr}");
                 }
             } else {
-                eprintln!("Failed to execute trigger: {run} {args:?}");
+                tracing::warn!("Failed to execute trigger: {run} {args:?}");
             }
         }
         Handler::Delete { .. } => todo!(),

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -139,7 +139,16 @@ pub fn prune(
         .collect::<Vec<_>>();
 
     // Print out the states to be removed to the user
-    println!("The following state(s) will be removed:");
+    tracing::info!("The following state(s) will be removed:");
+    for package in removals.iter() {
+        tracing::trace!(
+            type = "state",
+            action = "remove",
+            id = %package.id,
+            kind = %package.kind,
+            created = %package.created
+        );
+    }
     println!();
     autoprint_columns(&removals.iter().map(state::ColumnDisplay).collect::<Vec<_>>());
     println!();

--- a/moss/src/installation/lockfile.rs
+++ b/moss/src/installation/lockfile.rs
@@ -40,7 +40,7 @@ pub fn acquire(path: impl Into<PathBuf>, block_msg: impl fmt::Display) -> Result
     match flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
         Ok(_) => {}
         Err(nix::errno::Errno::EWOULDBLOCK) => {
-            println!("{block_msg}");
+            tracing::error!("{block_msg}");
             flock(file.as_raw_fd(), FlockArg::LockExclusive)?;
         }
         Err(e) => Err(e)?,

--- a/moss/src/main.rs
+++ b/moss/src/main.rs
@@ -4,12 +4,51 @@
 
 use std::error::Error;
 
-use tui::Styled;
+use tracing::Level;
+use tracing_subscriber::{
+    fmt,
+    Layer,
+    filter::LevelFilter,
+    filter::filter_fn,
+    Registry,
+    layer::SubscriberExt,
+};
 
 mod cli;
 
 /// Main entry point
 fn main() {
+    // Write log to /tmp/moss.json
+    let file_appender = tracing_appender::rolling::daily("/tmp", "moss.json");
+    let (non_blocking_appender, _guard) = tracing_appender::non_blocking(file_appender);
+
+    let fmt_layer_file = fmt::layer()
+        .json()
+        .with_writer(non_blocking_appender);
+
+    // Write ERROR and WARN to console
+    let fmt_layer_err = fmt::layer()
+        .with_level(true)
+        .with_target(false)
+        .without_time()
+        .with_filter(LevelFilter::WARN);
+
+    // Write INFO to console
+    let fmt_layer_out = fmt::layer()
+        .with_level(false)
+        .with_target(false)
+        .without_time()
+        .with_filter(filter_fn(|metadata| {metadata.level() == &Level::INFO}));
+
+    //
+    let subscriber = Registry::default()
+        .with(fmt_layer_file)
+        .with(fmt_layer_err)
+        .with(fmt_layer_out);
+
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Unable to set a global subscriber");
+
     if let Err(error) = cli::process() {
         report_error(error);
         std::process::exit(1);
@@ -20,7 +59,7 @@ fn main() {
 fn report_error(error: cli::Error) {
     let sources = sources(&error);
     let error = sources.join(": ");
-    eprintln!("{}: {error}", "Error".red());
+    tracing::error!("{error}");
 }
 
 /// Accumulate sources through error chains

--- a/moss/src/repository/manager.rs
+++ b/moss/src/repository/manager.rs
@@ -156,7 +156,7 @@ impl Manager {
 
                 self.refresh(id).await?;
 
-                pb.suspend(|| println!("{} {}", "Refreshed".green(), *id));
+                pb.suspend(|| tracing::info!("{} {}", "Refreshed".green(), *id));
 
                 Ok(())
             })
@@ -210,7 +210,7 @@ impl Manager {
 
                 self.refresh(id).await?;
 
-                pb.suspend(|| println!("{} {}", "Refreshed".green(), *id));
+                pb.suspend(|| tracing::info!("{} {}", "Refreshed".green(), *id));
 
                 Ok(()) as Result<_, Error>
             })


### PR DESCRIPTION
**Matrix**:
> _ermo_
> You interested in helping to add `trace::` for either boulder or moss?  (edited)
> everything that's currently `println` or `eprintln` needs to be converted to `tracing`  (edited)
> the longer term goal is better instrumentation around errors
> so high-value donkey work
> in fact, I'm hoping to rally a few contributors and do a boulder + moss `tracing::` sprint (edited)
> 
> _Ikey Doherty_
> no not `log` sorry
> `tracing`

I've started working on implementing `tracing`, since it's a relatively simple task that.

**Note**:
I code as a hobby, mainly in nushell, sometimes bash, or rarely in python. 
Which is to say I have _poor_ rust skills, feel free to give feed back on areas that need improvement.

---

progress on `moss`:
- [x] `eprintln` and `println` are `tracing::` calls
   - [ ] `cli/inspect.rs` `cli/info.rs`
- [x] only `tracing` `info`, `warn`, `error` are printed to the console 
  - [x] `tracing::info` only the message is printed
  - [x] `tracing::ward` and `tracing::error` the prefix `warn` or `error` is printed in addition the to the message
- [x] moss now makes a json log file @ `/tmp/moss.json` (all trace levels are printed)