### PR TITLE
Arch: aarch fixes and add riscv64 definition

### DIFF
--- a/boulder/data/macros/arch/aarch64.yaml
+++ b/boulder/data/macros/arch/aarch64.yaml
@@ -5,9 +5,9 @@ definitions:
     - libsuffix      : ""
     - build_platform : aarch64-%(vendorID)
     - host_platform  : aarch64-%(vendorID)
-    - cc             : "%(compiler_c) -m64"
-    - cxx            : "%(compiler_cxx) -m64"
-    - cpp            : "%(compiler_cpp) -m64"
+    - cc             : "%(compiler_c)"
+    - cxx            : "%(compiler_cxx)"
+    - cpp            : "%(compiler_cpp)"
     - march          : armv8-a+simd+fp+crypto
     - mtune          : cortex-a72.cortex-a53
     - target_triple  : "aarch64-unknown-linux-gnu"

--- a/boulder/data/macros/arch/riscv64.yaml
+++ b/boulder/data/macros/arch/riscv64.yaml
@@ -1,0 +1,24 @@
+# Provides -m64 builds for riscv64 build-hosts
+
+definitions:
+
+    - libsuffix      : ""
+    - build_platform : riscv64-%(vendorID)
+    - host_platform  : riscv64-%(vendorID)
+    - cc             : "%(compiler_c)"
+    - cxx            : "%(compiler_cxx)"
+    - cpp            : "%(compiler_cpp)"
+    - march          : rv64gc
+    - mtune          : generic-ooo
+    - target_triple  : "riscv64gc-unknown-linux-gnu"
+
+flags:
+
+    # Set architecture flags
+    - architecture:
+        llvm:
+            c         : "-march=rv64gc -mtune=generic-ooo"
+            cxx       : "-march=rv64gc -mtune=generic-ooo"
+        gcc:
+            c         : "-march=rv64gc -mtune=generic-ooo"
+            cxx       : "-march=rv64gc -mtune=generic-ooo"

--- a/boulder/src/architecture.rs
+++ b/boulder/src/architecture.rs
@@ -17,6 +17,10 @@ pub const fn host() -> Architecture {
     {
         Architecture::Aarch64
     }
+    #[cfg(target_arch = "riscv64")]
+    {
+        Architecture::Riscv64
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, strum::Display)]
@@ -25,6 +29,7 @@ pub enum Architecture {
     X86_64,
     X86,
     Aarch64,
+    Riscv64,
 }
 
 impl Architecture {
@@ -33,6 +38,7 @@ impl Architecture {
             Architecture::X86_64 => true,
             Architecture::X86 => false,
             Architecture::Aarch64 => true,
+            Architecture::Riscv64 => true,
         }
     }
 }


### PR DESCRIPTION
RISC-V:
    LLVM: Doesn't yet support generic-ooo
AARCH64:
    GCC: While passing -m64 in clang is fine, its not for gcc