### PR TITLE
boulder/macros: Update cmake/ninja/meson macros

### DIFF
--- a/boulder/data/macros/actions/cmake.yaml
+++ b/boulder/data/macros/actions/cmake.yaml
@@ -3,50 +3,73 @@ actions:
     - cmake:
         description: Perform cmake with the default options in a subdirectory
         command: |
-            cmake %(options_cmake)
+            cmake %(options_cmake_ninja)
         dependencies:
             - binary(cmake)
+            - binary(ninja)
+
+    - cmake_make:
+        description: Perform cmake with the default options using make as the build server
+        command: |
+            cmake %(options_cmake_make)
+        dependencies:
+            - binary(cmake)
+            - binary(make)
 
     - cmake_unity:
         description: Perform cmake with unity build enabled
         command: |
-            cmake -DCMAKE_UNITY_BUILD=ON %(options_cmake)
+            cmake -DCMAKE_UNITY_BUILD=ON %(options_cmake_ninja)
         dependencies:
             - binary(cmake)
 
     - cmake_build:
         description: Build the cmake project
         command: |
-            ninja -v -j "%(jobs)" -C "%(builddir)"
+            cmake --build "${BUILDDIR:-%(builddir)}" --verbose --parallel "%(jobs)"
         dependencies:
-            - binary(ninja)
+            - binary(cmake)
 
     - cmake_install:
         description: Install results of the build to the destination directory
         command: |
-            DESTDIR="%(installroot)" ninja install -v -j "%(jobs)" -C "%(builddir)"
+            DESTDIR="%(installroot)" cmake --install "${BUILDDIR:-%(builddir)}" --verbose
         dependencies:
-            - binary(ninja)
+            - binary(cmake)
 
     - cmake_test:
         description: Run testsuite with ctest
         command: |
-            ninja test -v -j "%(jobs)" -C "%(builddir)"
+            ctest --test-dir "${BUILDDIR:-%(builddir)}" --verbose --parallel "%(jobs)" --output-on-failure --force-new-ctest-process
         dependencies:
-            - binary(cmake)
-            - binary(ninja)
+            - binary(ctest)
 
 definitions:
 
     # Default cmake options as passed to cmake
+    # - _RELEASE variables are added AFTER environmental variables are parsed
+    #   and default to `-O3 -DNDEBUG`. Strip the `-O3` so we can manage that with
+    #   our flags.
+    # - Turn on verbose makefiles so we can make sure our flags are being used
+    # - Turn off stripping by default since Boulder does that
     - options_cmake: |
-        -G Ninja -S . -B "%(builddir)" \
-        -DCMAKE_C_FLAGS="${CFLAGS}" \
-        -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
-        -DCMAKE_C_FLAGS_RELEASE="" \
-        -DCMAKE_CXX_FLAGS_RELEASE="" \
-        -DCMAKE_LD_FLAGS="${LDFLAGS}" \
+        -B "%(builddir)" \
+        -DCMAKE_VERBOSE_MAKEFILE=ON \
+        -DCMAKE_C_FLAGS_RELEASE="-DNDEBUG" \
+        -DCMAKE_CXX_FLAGS_RELEASE="-DNDEBUG" \
+        -DCMAKE_Fortran_FLAGS_RELEASE="-DNDEBUG" \
         -DCMAKE_BUILD_TYPE="Release" \
+        -DCMAKE_INSTALL_DO_STRIP=OFF \
         -DCMAKE_INSTALL_LIBDIR="lib" \
         -DCMAKE_INSTALL_PREFIX="%(prefix)" \
         -DCMAKE_LIB_SUFFIX="%(libsuffix)"
+
+    # Use cmake with ninja as the build server
+    - options_cmake_ninja: |
+        -G Ninja \
+        %(options_cmake)
+
+    # Use cmake with make as the build server
+    - options_cmake_make: |
+        -G Unix Makefiles \
+        %(options_cmake)

--- a/boulder/data/macros/actions/meson.yaml
+++ b/boulder/data/macros/actions/meson.yaml
@@ -4,7 +4,7 @@ actions:
         description: Run meson with the default options in a subdirectory
         command: |
             test -e ./meson.build || ( echo "%%meson: The ./meson.build script could not be found" ; exit 1 )
-            CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" meson setup %(options_meson)
+            meson setup %(options_meson) "%(builddir)"
         dependencies:
             - binary(cmake)
             - binary(meson)
@@ -14,7 +14,7 @@ actions:
         description: Run meson with unity build enabled
         command: |
             test -e ./meson.build || ( echo "%%meson: The ./meson.build script could not be found" ; exit 1 )
-            CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" meson setup --unity on %(options_meson)
+            meson setup --unity on %(options_meson) "%(builddir)"
         dependencies:
             - binary(cmake)
             - binary(meson)
@@ -23,7 +23,7 @@ actions:
     - meson_build:
         description: Build the meson project
         command: |
-            meson compile -v -j "%(jobs)" -C "%(builddir)"
+            meson compile --verbose -j "%(jobs)" -C "%(builddir)"
         dependencies:
             - binary(meson)
 
@@ -37,7 +37,7 @@ actions:
     - meson_test:
         description: Run meson test
         command: |
-            meson test --no-rebuild --print-errorlogs -j "%(jobs)" -C "%(builddir)"
+            meson test --no-rebuild --print-errorlogs --verbose -j "%(jobs)" -C "%(builddir)"
         dependencies:
             - binary(meson)
 
@@ -45,10 +45,17 @@ definitions:
 
     # Default meson options as passed to meson
     - options_meson: |
-        --prefix="%(prefix)" \
         --buildtype="plain" \
+        --prefix="%(prefix)" \
         --libdir="lib%(libsuffix)" \
+        --bindir="%(bindir)" \
+        --sbindir="%(sbindir)" \
         --libexecdir="lib%(libsuffix)/%(name)" \
+        --includedir="%(includedir)" \
+        --datadir="%(datadir)" \
+        --mandir="%(mandir)" \
+        --infodir="%(infodir)" \
+        --localedir="%(localedir)" \
         --sysconfdir="%(sysconfdir)" \
         --localstatedir="%(localstatedir)" \
-        "%(builddir)"
+        --wrap-mode="nodownload"

--- a/boulder/data/macros/actions/ninja.yaml
+++ b/boulder/data/macros/actions/ninja.yaml
@@ -1,0 +1,25 @@
+actions:
+    - ninja:
+        description: Use ninja, without any additional arguments this will run the default target (likely the build)
+        command: |
+            %(ninja_common)
+        dependencies:
+            - binary(ninja)
+
+    - ninja_install:
+        description: Use ninja to install the build results to the installroot
+        command: |
+            DESTDIR="%(installroot)" %(ninja_common) install
+        dependencies:
+            - binary(ninja)
+
+    - ninja_test:
+        description: Use ninja to run the test suite
+        command: |
+            %(ninja_common) test
+        dependencies:
+            - binary(ninja)
+
+definitions:
+    - ninja_common: |
+        ninja --verbose -j "%(jobs)" -C "%(builddir)"

--- a/boulder/data/macros/actions/qt-kde.yaml
+++ b/boulder/data/macros/actions/qt-kde.yaml
@@ -96,7 +96,7 @@ definitions:
 
     # Default options for Qt6 builds
     - options_cmake_qt6: |
-        %(options_cmake) \
+        %(options_cmake_ninja) \
         -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
         -DCMAKE_MESSAGE_LOG_LEVEL=STATUS \
         -DINSTALL_ARCHDATADIR=%(libdir)/qt6 \
@@ -114,7 +114,7 @@ definitions:
 
     # Default options for KF6/Qt6 builds
     - options_cmake_kf6: |
-        %(options_cmake) \
+        %(options_cmake_ninja) \
         -DCMAKE_INSTALL_LIBEXECDIR_kf6:PATH=%(libdir)/kf6 \
         -DKDE_INSTALL_LIBEXECDIR:PATH=%(libdir)/kf6 \
         -DKDE_INSTALL_USE_QT_SYS_PATHS:BOOL=ON \


### PR DESCRIPTION
Cmake:
- Re-introduce support for using make as the build server
- Switch to invoking the build server via cmake directly
- Update ctest options
- Fix handling of build flags
  - Build flags are now imported from environment directly
  - `-DNDEBUG` is now correctly added to build flags when using `Release` profile
- Enable verbose makefiles and disable stripping by default

Ninja:
- Add ninja-specific macros for building, installing, and testing

Meson:
- Remove unnecessary exports of build flags
- Update build options