### PR TITLE
boulder: Add Fortran support

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -66,6 +66,7 @@ actions              :
             CGO_CFLAGS="%(cflags)"; export CGO_CFLAGS
             CXXFLAGS="%(cxxflags)"; export CXXFLAGS
             CGO_CXXFLAGS="%(cxxflags)"; export CGO_CXXFLAGS
+            FFLAGS="%(fflags)"; export FFLAGS
             LDFLAGS="%(ldflags)"; export LDFLAGS
             CGO_LDFLAGS="%(ldflags) -Wl,--no-gc-sections"; export CGO_LDFLAGS
             DFLAGS="%(dflags)"; export DFLAGS
@@ -325,6 +326,7 @@ flags               :
     - base:
         c         : "-pipe -Wformat -Wformat-security -Wno-error -fPIC"
         cxx       : "-pipe -Wformat -Wformat-security -Wno-error -fPIC"
+        f         : ""
         ld        : "-Wl,-O2,--gc-sections"
         d         : "-release -Hkeep-all-bodies -relocation-model=pic -wi"
         rust      : "-C strip=none"
@@ -332,12 +334,14 @@ flags               :
     - omit-frame-pointer:
         c         : "-fomit-frame-pointer -momit-leaf-frame-pointer"
         cxx       : "-fomit-frame-pointer -momit-leaf-frame-pointer"
+        f         : "-fomit-frame-pointer"
         d         : "-frame-pointer=none"
         rust      : ""
 
     - no-omit-frame-pointer:
         c         : "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
         cxx       : "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+        f         : "-fno-omit-frame-pointer"
         d         : "-frame-pointer=all"
         rust      : "-C force-frame-pointers"
 
@@ -360,6 +364,7 @@ flags               :
     - fortify:
         c         : "-D_FORTIFY_SOURCE=2"
         cxx       : "-D_FORTIFY_SOURCE=2"
+        f         : "-D_FORTIFY_SOURCE=2"
 
     # No hardening!
     - harden-none:
@@ -388,11 +393,13 @@ flags               :
     - optimize-fast:
         c         : "-Ofast"
         cxx       : "-Ofast"
+        f         : "-Ofast"
 
     # Generic optimisation case (ON)
     - optimize-generic:
         c         : "-O2"
         cxx       : "-O2"
+        f         : "-O2"
         d         : "-O2"
         # opt-level=3 is common in the rust world so let that
         # be our generic opt case.
@@ -404,11 +411,14 @@ flags               :
         cxx   : "-Os"
         d     : "-Os"
         rust  : "-C opt-level=s -C codegen-units=16"
+        gnu:
+            f : "-Os"
 
     # Optimize for speed (OFF)
     - optimize-speed:
         c         : "-O3"
         cxx       : "-O3"
+        f         : "-O3"
         d         : "-O3"
         rust      : "-C opt-level=3 -C codegen-units=16"
 
@@ -418,10 +428,12 @@ flags               :
         gnu:
             c         : "-flto=%(jobs) -flto-partition=one"
             cxx       : "-flto=%(jobs) -flto-partition=one"
+            f         : "-flto=%(jobs) -flto-partition=one"
             ld        : "-flto=%(jobs) -flto-partition=one"
         llvm:
             c         : "-flto=full"
             cxx       : "-flto=full"
+            f         : "-flto=full"
             d         : "-flto=full"
             ld        : "-flto=full"
 
@@ -431,10 +443,12 @@ flags               :
         gnu:
             c         : "-flto=%(jobs)"
             cxx       : "-flto=%(jobs)"
+            f         : "-flto=%(jobs)"
             ld        : "-flto=%(jobs)"
         llvm:
             c         : "-flto=thin"
             cxx       : "-flto=thin"
+            f         : "-flto=thin"
             d         : "-flto=thin"
             ld        : "-flto=thin"
 
@@ -457,11 +471,15 @@ flags               :
     - fat-lto:
         c         : "-ffat-lto-objects"
         cxx       : "-ffat-lto-objects"
+        gnu       :
+            f     : "-ffat-lto-objects"
 
     # Disable Fat LTO Objects (OFF)
     - fat-lto-none:
         c         : "-fno-fat-lto-objects"
         cxx       : "-fno-fat-lto-objects"
+        gnu       :
+            f     : "-fno-fat-lto-objects"
 
     # Toggle LTO warning errors. If these throw an error it is likely that there will be runtime problems with LTO (ON)
     - lto-errors:
@@ -518,6 +536,7 @@ flags               :
         llvm:
             c     : "-fplugin=LLVMPolly.so -fpass-plugin=LLVMPolly.so -Xclang -mllvm -Xclang -polly -Xclang -mllvm -Xclang -polly-vectorizer=stripmine"
             cxx   : "-fplugin=LLVMPolly.so -fpass-plugin=LLVMPolly.so -Xclang -mllvm -Xclang -polly -Xclang -mllvm -Xclang -polly-vectorizer=stripmine"
+            f     : "-fpass-plugin=LLVMPolly.so" # TODO: I don't think this does anything, but at least it doesn't fail
             d     : "-polly -polly-vectorizer=stripmine"
 
     # Toggle options you want to use with llvm-bolt (OFF)
@@ -535,6 +554,8 @@ flags               :
     - common:
         c         : "-fcommon"
         cxx       : "-fcommon"
+        gnu       :
+            f     : "-fcommon"
 
     # Toggle debug-lines optimisations
     - debug-lines:
@@ -546,6 +567,7 @@ flags               :
 
     # Toggle debug-std optimisations (ON)
     - debug-std:
+        f         : "-g"
         d         : "-g -gc -d-debug"
         rust      : "-C debuginfo=2 -C split-debuginfo=off"
         gnu:
@@ -557,6 +579,7 @@ flags               :
 
     # Toggle fast math (OFF)
     - math:
+        f         : "-ffast-math"
         d         : "-ffast-math -fp-contract=fast"
         gnu:
             c         : "-fno-math-errno -fno-trapping-math"
@@ -570,6 +593,8 @@ flags               :
         c         : "-fno-plt"
         cxx       : "-fno-plt"
         d         : "-fno-plt"
+        gnu:
+            f     : "-fno-plt"
 
     # Toggle -fno-semantic-interposition (OFF)
     - nosemantic:
@@ -586,6 +611,8 @@ flags               :
     - avxwidth-128:
         c         : "-mprefer-vector-width=128"
         cxx       : "-mprefer-vector-width=128"
+        gnu:
+            f     : "-mprefer-vector-width=128"
 
     # Toggle -fpch-instantiate-templates (OFF)
     - pch-instantiate:
@@ -606,12 +633,15 @@ flags               :
         gnu:
             c         : "-msse2avx"
             cxx       : "-msse2avx"
+            f         : "-msse2avx"
 
     # Toggle visibility hidden (OFF)
     - visibility-hidden:
         c          : "-fvisibility=hidden"
         cxx        : "-fvisibility-inlines-hidden -fvisibility=hidden"
         d          : "-fvisibility=hidden"
+        gnu:
+            f      : "-fvisibility=hidden"
 
     # Toggle visibility inlines hidden (OFF)
     - visibility-inline:

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -361,6 +361,11 @@ fn add_tuning(
             .iter()
             .filter_map(|flag| flag.get(tuning::CompilerFlag::Cxx, toolchain)),
     );
+    let fflags = fmt_flags(
+        flags
+            .iter()
+            .filter_map(|flag| flag.get(tuning::CompilerFlag::F, toolchain)),
+    );
     let ldflags = fmt_flags(
         flags
             .iter()
@@ -385,6 +390,7 @@ fn add_tuning(
 
     parser.add_definition("cflags", cflags);
     parser.add_definition("cxxflags", cxxflags);
+    parser.add_definition("fflags", fflags);
     parser.add_definition("ldflags", ldflags);
     parser.add_definition("dflags", dflags);
     parser.add_definition("rustflags", rustflags);

--- a/crates/stone_recipe/src/tuning.rs
+++ b/crates/stone_recipe/src/tuning.rs
@@ -83,6 +83,7 @@ impl TuningFlag {
 pub enum CompilerFlag {
     C,
     Cxx,
+    F,
     D,
     Rust,
     Ld,
@@ -92,6 +93,7 @@ pub enum CompilerFlag {
 pub struct CompilerFlags {
     c: Option<String>,
     cxx: Option<String>,
+    f: Option<String>,
     d: Option<String>,
     rust: Option<String>,
     ld: Option<String>,
@@ -102,6 +104,7 @@ impl CompilerFlags {
         match flag {
             CompilerFlag::C => self.c.as_deref(),
             CompilerFlag::Cxx => self.cxx.as_deref(),
+            CompilerFlag::F => self.f.as_deref(),
             CompilerFlag::D => self.d.as_deref(),
             CompilerFlag::Rust => self.rust.as_deref(),
             CompilerFlag::Ld => self.ld.as_deref(),


### PR DESCRIPTION
This adds FFLAGS to the boulder build env. I tested the various flags supported by gfortran and flang and added them where appropriate.