### PR TITLE
boulder: Normalize python providers

### DIFF
--- a/boulder/src/package/analysis/handler.rs
+++ b/boulder/src/package/analysis/handler.rs
@@ -144,6 +144,14 @@ pub fn python(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Respons
         name: python_name.to_string(),
     });
 
+    if python_name.contains("_") {
+        /* Insert normalized generic provider */
+        bucket.providers.insert(Provider {
+            kind: dependency::Kind::Python,
+            name: python_name.replace("_", "-"),
+        });
+    }
+
     let output = Command::new("/usr/bin/python3")
         .arg("-c")
         .arg("import platform; print(f'{platform.python_version_tuple()[0]}.{platform.python_version_tuple()[1]}')")
@@ -156,6 +164,18 @@ pub fn python(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Respons
         kind: dependency::Kind::Python,
         name: format!("{python_name}({})", &python_version.to_string().trim_end()),
     });
+
+    if python_name.contains("_") {
+        /* Insert normalized versioned provider */
+        bucket.providers.insert(Provider {
+            kind: dependency::Kind::Python,
+            name: format!(
+                "{}({})",
+                python_name.replace("_", "-"),
+                &python_version.to_string().trim_end()
+            ),
+        });
+    }
 
     /* Now parse dependencies */
     let dist_path = info


### PR DESCRIPTION
Boulder generates providers by using the module's name. If module's name contains a '_', it will cause a provider/dependency mismatch. This is solved by simply adding additional providers by replacing '_' with '-' in the module's name.

I tested it by rebuilding python-typing_extensions and it got resolved, even if the module is looking for python(typing-extensions(3.11)), which got generated by boulder too.