### PR TITLE
boulder: Add CCACHE_BASEDIR to improve cache hit rates

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -3,28 +3,31 @@
 definitions:
 
     # Basic variables required for packages to build correctly
-    - libsuffix      : ""
-    - prefix         : "/usr"
-    - bindir         : "%(prefix)/bin"
-    - sbindir        : "%(prefix)/sbin"
-    - includedir     : "%(prefix)/include"
-    - datadir        : "%(prefix)/share"
-    - localedir      : "%(datadir)/locale"
-    - infodir        : "%(datadir)/info"
-    - mandir         : "%(datadir)/man"
-    - docdir         : "%(datadir)/doc"
-    - vendordir      : "%(datadir)/defaults"
-    - completionsdir : "%(datadir)/bash-completion/completions"
-    - tmpfilesdir    : "%(prefix)/lib/tmpfiles.d"
-    - sysusersdir    : "%(prefix)/lib/sysusers.d"
-    - udevrulesdir   : "%(prefix)/lib/udev/rules.d"
-    - localstatedir  : "/var"
-    - sharedstatedir : "%(localstatedir)/lib"
-    - runstatedir    : "/run"
-    - sysconfdir     : "/etc"
-    - libdir         : "%(prefix)/lib%(libsuffix)"
-    - libexecdir     : "%(libdir)/%(name)"
-    - builddir       : "serpent_builddir"
+    - libsuffix          : ""
+    - prefix             : "/usr"
+    - bindir             : "%(prefix)/bin"
+    - sbindir            : "%(prefix)/sbin"
+    - includedir         : "%(prefix)/include"
+    - datadir            : "%(prefix)/share"
+    - localedir          : "%(datadir)/locale"
+    - infodir            : "%(datadir)/info"
+    - mandir             : "%(datadir)/man"
+    - docdir             : "%(datadir)/doc"
+    - vendordir          : "%(datadir)/defaults"
+    - completionsdir     : "%(datadir)/bash-completion/completions"
+    - zshcompletionsdir  : "%(datadir)/zsh/site-functions"
+    - fishcompletionsdir : "%(datadir)/fish/vendor_completions.d"
+    - elvishcompletions  : "%(datadir)/elvish/lib"
+    - tmpfilesdir        : "%(prefix)/lib/tmpfiles.d"
+    - sysusersdir        : "%(prefix)/lib/sysusers.d"
+    - udevrulesdir       : "%(prefix)/lib/udev/rules.d"
+    - localstatedir      : "/var"
+    - sharedstatedir     : "%(localstatedir)/lib"
+    - runstatedir        : "/run"
+    - sysconfdir         : "/etc"
+    - libdir             : "%(prefix)/lib%(libsuffix)"
+    - libexecdir         : "%(libdir)/%(name)"
+    - builddir           : "serpent_builddir"
 
     # The vendorID is encoded into the triplet, toolchain, builds, etc.
     # It must match the triplet from bootstrap-scripts.
@@ -95,6 +98,7 @@ actions              :
             LC_ALL="en_US.UTF-8"; export LC_ALL
             test -d "%(workdir)" || (echo "The work directory %(workdir) does not exist"; exit 1)
             cd "%(workdir)" && echo "The work directory %%(workdir) is ${PWD}"
+            CCACHE_BASEDIR="%(workdir)"; export CCACHE_BASEDIR
 
 defaultTuningGroups :
     - asneeded


### PR DESCRIPTION
ccache resolves absolute paths to source files and uses that path as part of the cache key. In practice this means that changing the build directory invalidates all builds using a previous build directory, and given that the source archive name typically ends up being part of the build path (for instance `/mason/build/x86_64/llvm-project-20.1.4.src.tar.xz/`) the end result is that updating the version of a package is enough to invalidate all ccache entries from a previous version.

To fix this we can use the CCACHE_BASEDIR environmental variable. If set ccache will strip the value of it from the cache key (for instance `/mason/build/x86_64/llvm-project-20.1.4.src.tar.xz/src/foo.c` with a `CCACHE_BASEDIR=/mason/build/x86_64/llvm-project-20.1.4.src.tar.xz/` will be stored as `src/foo.c`) which means that ccache entries can persist between version updates. Given that ccache already hashes the file contents as part of the cache key this shouldn't cause any issues and should improve cache hit rates quite a bit.

Also while we're at it add macro definitions for the zsh, fish, and elvish shell completions directories since that's a trivial change not really deserving of a separate PR.