### PR TITLE
boulder: use /usr/bin/bash for script shebangs

### DIFF
--- a/boulder/data/macros/actions/autotools.yaml
+++ b/boulder/data/macros/actions/autotools.yaml
@@ -1,49 +1,112 @@
 actions:
 
-    - configure:
-        description: Perform ./configure with the default options
-        command: |
-            test -x ./configure || ( echo "%%configure: The ./configure script could not be found" ; exit 1 )
-            ./configure %(options_configure)
-        dependencies:
-            - binary(autoconf)
-            - binary(automake)
+    # We default to using CONFIG_SHELL==SHELL=/usr/bin/dash because our tests show that it is around
+    # +20% faster than bash on startup, which matters on large configure runs with hundreds of tests.
+    #
+    # To use bash instead of dash, use the bash-specific *_with_bash version of the relevant macro action.
 
-    # TIP: Add V=1 VERBOSE=1 after '%make' in the recipe if you need a more verbose build
-    - make:
-        description: Perform a make
+    - autogen:
+        description: Run autogen.sh script with dash, attempting to only run ./configure once
         command: |
-            make -j "%(jobs)"
-        dependencies:
-            - binary(make)
-
-    - make_install:
-        description: Install results of build to the destination directory
-        command: |
-            %make install DESTDIR="%(installroot)"
-        dependencies:
-            - binary(make)
-
-    - reconfigure:
-        description: Re autotools-configure a project without an autogen.sh script
-        command: |
-            autoreconf -vfi || ( echo "%%reconfigure: Failed to run autoreconf"; exit 1 )
+            NOCONFIGURE="noconfigure"; export NOCONFIGURE
+            # Often defaults to /bin/sh
+            CONFIG_SHELL=/usr/bin/dash; export CONFIG_SHELL
+            SHELL=/usr/bin/dash; export SHELL
+            /usr/bin/dash ./autogen.sh %(options_configure)
+            echo "Configured to use '$(head -n1 ./configure)' to execute ./configure"
             %configure
         dependencies:
             - binary(autoconf)
             - binary(automake)
             - binary(autopoint)
 
-    - autogen:
-        description: Run autogen.sh script, attempting to only configure once
+    - autogen_with_bash:
+        description: Run autogen.sh script with GNU Bash, attempting to only run ./configure once
         command: |
             NOCONFIGURE="noconfigure"; export NOCONFIGURE
-            sh ./autogen.sh %(options_configure)
-            ./configure %(options_configure)
+            CONFIG_SHELL=/usr/bin/bash; export CONFIG_SHELL
+            SHELL=/usr/bin/bash; export SHELL
+            /usr/bin/bash ./autogen.sh %(options_configure)
+            echo "Configured to use '$(head -n1 ./configure)' to execute ./configure"
+            %configure_with_bash
         dependencies:
             - binary(autoconf)
             - binary(automake)
             - binary(autopoint)
+
+    - configure:
+        description: |
+            Perform ./configure with the default options using the dash shell.
+            In our testing, dash has been shown to be +20% faster to start up than bash on average.
+        command: |
+            test -x ./configure || ( echo "%%configure: The ./configure script could not be found" ; exit 1 )
+            # Rewrite any '#!*/bin/sh' shebang to '#!/usr/bin/dash' instead
+            # '-E' means "Use Extended Regular Expressions" (easier to write and read)
+            CONFIG_SHELL=/usr/bin/dash; export CONFIG_SHELL
+            SHELL=/usr/bin/dash; export SHELL
+            echo "Explicitly using dash to execute ./configure"
+            /usr/bin/dash ./configure %(options_configure)
+        dependencies:
+            - binary(autoconf)
+            - binary(automake)
+
+    - configure_with_bash:
+        description: Perform ./configure with default options using the GNU Bash shell.
+        command: |
+            test -x ./configure || ( echo "%%configure: The ./configure script could not be found" ; exit 1 )
+            CONFIG_SHELL=/usr/bin/dash; export CONFIG_SHELL
+            SHELL=/usr/bin/dash; export SHELL
+            echo "Explicitly using GNU Bash to execute ./configure"
+            /usr/bin/bash ./configure %(options_configure)
+        dependencies:
+            - binary(autoconf)
+            - binary(automake)
+
+    - make:
+        description: |
+            Perform a `make` to build the current Makefile.
+            Tip: Add V=1 VERBOSE=1 after `%%make` in the recipe if you need a more verbose build.
+        command: |
+            make -j "%(jobs)"
+        dependencies:
+            - binary(make)
+
+    - make_install:
+        description: Use make to install the results of a build to the destination directory
+        Tip: If a make install operation falls over with parallel builds, try `%%make_install -j1` instead.
+        command: |
+            %make install DESTDIR="%(installroot)"
+        dependencies:
+            - binary(make)
+
+    - reconfigure:
+        description: Re autotools-configure a project without an autogen.sh script using dash
+        command: |
+            # The autoreconf perl script defaults to /bin/sh if SHELL is not set
+            CONFIG_SHELL=/usr/bin/dash; export CONFIG_SHELL
+            SHELL=/usr/bin/dash; export SHELL
+            autoreconf -vfi || ( echo "%%reconfigure: Failed to run autoreconf" ; exit 1 )
+            echo "Configured to use '$(head -n1 ./configure)' to execute ./configure"
+            %configure
+        dependencies:
+            - binary(autoconf)
+            - binary(automake)
+            - binary(autopoint)
+
+    - reconfigure_with_bash:
+        description: Re autotools-configure a project without an autogen.sh script using GNU Bash
+        command: |
+            # The autoreconf perl script defaults to /bin/sh if SHELL is not set
+            CONFIG_SHELL=/usr/bin/bash; export CONFIG_SHELL
+            SHELL=/usr/bin/bash; export SHELL
+            autoreconf -vfi || ( echo "%%reconfigure: Failed to run autoreconf" ; exit 1 )
+            echo "Configured to use '$(head -n1 ./configure)' to execute ./configure"
+            %configure_with_bash
+        dependencies:
+            - binary(autoconf)
+            - binary(automake)
+            - binary(autopoint)
+
 
 definitions:
 

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -55,7 +55,7 @@ actions              :
     - scriptBase     :
         description: scriptBase is merged to the top of all newly generated build scripts.
         command: |
-            #!/bin/sh
+            #!/usr/bin/bash
             set -e
             set -x
             TERM="dumb"; export TERM

--- a/boulder/data/profile.d/default-x86_64.yaml
+++ b/boulder/data/profile.d/default-x86_64.yaml
@@ -2,5 +2,5 @@ default-x86_64:
   repositories:
     volatile:
       uri: "https://packages.aerynos.com/volatile/x86_64/stone.index"
-      description: "Volatile Aeryn OS repo"
+      description: "Volatile AerynOS repo"
       priority: 0

--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -205,7 +205,7 @@ impl Builder {
                                 // Write env to $HOME/.profile
                                 fs::write(build_dir.join(".profile"), format_profile(script))?;
 
-                                let mut command = process::Command::new("/bin/bash")
+                                let mut command = process::Command::new("/usr/bin/bash")
                                     .arg("--login")
                                     .env_clear()
                                     .env("HOME", build_dir)
@@ -228,7 +228,7 @@ impl Builder {
                                 let script_path = "/tmp/script";
                                 fs::write(script_path, content).unwrap();
 
-                                let result = logged(*phase, is_pgo, "/bin/sh", |command| {
+                                let result = logged(*phase, is_pgo, "/usr/bin/bash", |command| {
                                     command
                                         .arg(script_path)
                                         .env_clear()

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -196,9 +196,12 @@ const BASE_PACKAGES: &[&str] = &[
     "util-linux",
     // Needed for chroot
     "binary(git)",
+    "binary(hx)",
+    "binary(less)",
     "binary(nano)",
-    "binary(vim)",
     "binary(ps)",
+    "binary(rg)",
+    "binary(vim)",
 ];
 const BASE32_PACKAGES: &[&str] = &["glibc-32bit-devel"];
 

--- a/moss/src/client/boot.rs
+++ b/moss/src/client/boot.rs
@@ -234,7 +234,7 @@ pub fn synchronize(client: &Client, state: &State) -> Result<(), Error> {
 
     for entry in entries.iter_mut() {
         if let Err(e) = entry.load_cmdline_snippets(&config) {
-            log::warn!("Failed to load cmdline snippets: {}", e);
+            log::warn!("Failed to load cmdline snippets: {e}");
         }
     }
     // no usable entries, lets get out of here.


### PR DESCRIPTION
With this change, the build scripts generated by boulder from the stone.yaml recipes are no longer affected by the /usr/bin/sh symlink, which means that we can now safely point that to dash for a potential increase of up to +20% faster configure runs for e.g. gettext.

This commit also creates dedicated *_with_bash fallback autotools actions which should ensure that stubborn packages whose build systems rely on the presence of a bash shell can now simply use the *_with_bash actions.

In addition, add helix, less and ripgrep to roots for a nicer chroot experience when troubleshooting or writing/testing patches inside the chroot (yes, this is a really nice workflow actually).

TODO: The extra chroot packages really ought to be user-controlled (with a decent, if minimal fallback) as a boulder config option, along with optionally copying in the current user's .gitconfig to the root for easier patching inside chroots. See https://github.com/AerynOS/os-tools/issues/476 for the details.