### PR TITLE
boulder: Add CCACHE_BASEDIR to improve cache hit rates

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -86,6 +86,7 @@ actions              :
             STRIP="%(strip)"; export STRIP
             PATH="%(path)"; export PATH
             CCACHE_DIR="%(ccachedir)"; export CCACHE_DIR;
+            CCACHE_BASEDIR="%(workdir)"; export CCACHE_BASEDIR
             test -z "$CCACHE_DIR" && unset CCACHE_DIR;
             %cargo_set_environment
             RUSTC_WRAPPER="%(rustc_wrapper)"; export RUSTC_WRAPPER;


### PR DESCRIPTION
Courtesy and credit to @ReillyBrogan for the following:

> ccache resolves absolute paths to source files and uses that path as
> part of the cache key. In practice this means that changing the build
> directory invalidates all builds using a previous build directory,
> and given that the source archive name typically ends up being part of
> the build path (e.g. `/mason/build/x86_64/llvm-project-20.1.4.src.tar.xz/`)
> the end result is that updating the version of a package is enough to
> invalidate all ccache entries from a previous version.
>
> To fix this we can use the `CCACHE_BASEDIR` environmental variable.
> If set, ccache will strip the value of it from the cache key
> (e.g. `/mason/build/x86_64/llvm-project-20.1.4.src.tar.xz/src/foo.c`
>  w/ a `CCACHE_BASEDIR=/mason/build/x86_64/llvm-project-20.1.4.src.tar.xz/`
>  will be stored as `src/foo.c`), which means that ccache entries can
> persist between version updates.
>
> Given that ccache already hashes the file contents as part of the
> cache key this shouldn't cause any issues and should improve cache hit
> rates quite a bit.