### PR TITLE
boulder: Add %(completionsdir) for rebuild compat

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -18,6 +18,8 @@ definitions:
     - localedir            : "%(datadir)/locale"
     - mandir               : "%(datadir)/man"
     - bashcompletionsdir   : "%(datadir)/bash-completion/completions"
+    # TODO: Remove completionsdir once rebuilds are done and we are on Rust infra
+    - completionsdir       : "%(bashcompletionsdir)"
     - fishcompletionsdir   : "%(datadir)/fish/vendor_completions.d"
     - elvishcompletionsdir : "%(datadir)/elvish/lib"
     - zshcompletionsdir    : "%(datadir)/zsh/site-functions"


### PR DESCRIPTION
This needs to be removed once we are done rebuilding, so it can act as a signal that we need to redo recipes that use it.