### PR TITLE
boulder: Fix Qt/KDE macros

### DIFF
--- a/boulder/data/macros/actions/qt-kde.yaml
+++ b/boulder/data/macros/actions/qt-kde.yaml
@@ -24,6 +24,7 @@ actions:
             cmake %(options_cmake_qt6) ${_ccache_arg}
         dependencies:
             - binary(cmake)
+            - binary(ninja)
 
     - cmake_kf6:
         description: Perform cmake with the default options for KF6/Qt6 builds. This includes KDE Frameworks, Plasma, and KDE Gear
@@ -33,6 +34,7 @@ actions:
             cmake %(options_cmake_kf6)
         dependencies:
             - binary(cmake)
+            - binary(ninja)
             - cmake(ECM)
 
     - qt_user_facing_links:


### PR DESCRIPTION
Because we're constructing the cmake command manually (as opposed to say adding specific qt cmake options) we need to manually add binary(ninja) to the cmake deps.