### PR TITLE
Reduce debug info for dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,11 @@ wildcard_imports = "warn"
 # has false positives in indicatif usage
 literal_string_with_formatting_args = "allow"
 
+[profile.dev]
+# makes linking faster, enables everything needed for backtraces
+# for attaching an interactive debugger, use another profile
+debug = "line-tables-only"
+
 [profile.release]
 lto = "thin"
 


### PR DESCRIPTION
Reduces boulder debug binary size from over 260M to about 120M, and moss debug binary size from almost 230M to about 105M.