### PR TITLE
Remove "Id()" from Debug impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 crossterm = "0.28.1"
 derive_more = { version = "2.0.1", features = [
     "as_ref",
+    "debug",
     "display",
     "from",
     "into",

--- a/boulder/src/paths.rs
+++ b/boulder/src/paths.rs
@@ -4,9 +4,12 @@
 
 use std::{io, path::PathBuf};
 
+use derive_more::Debug;
+
 use crate::{util, Recipe};
 
 #[derive(Debug, Clone)]
+#[debug("{_0:?}")]
 pub struct Id(String);
 
 impl Id {

--- a/boulder/src/profile.rs
+++ b/boulder/src/profile.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use derive_more::Debug;
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -15,6 +16,7 @@ use crate::Env;
 
 /// A unique [`Profile`] identifier
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, Display)]
+#[debug("{_0:?}")]
 #[serde(from = "String")]
 pub struct Id(String);
 

--- a/moss/src/package/meta.rs
+++ b/moss/src/package/meta.rs
@@ -4,7 +4,7 @@
 
 use std::collections::BTreeSet;
 
-use derive_more::{AsRef, Display, From, Into};
+use derive_more::{AsRef, Debug, Display, From, Into};
 use stone::payload;
 use thiserror::Error;
 
@@ -12,6 +12,7 @@ use crate::{dependency, Dependency, Provider};
 
 /// A package identifier constructed from metadata fields
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Display)]
+#[debug("{_0:?}")]
 pub struct Id(pub(super) String);
 
 /// The name of a [`super::Package`]

--- a/moss/src/package/mod.rs
+++ b/moss/src/package/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use derive_more::{AsRef, Display, From, Into};
+use derive_more::{AsRef, Debug, Display, From, Into};
 use itertools::Itertools;
 
 pub use self::meta::{Meta, MissingMetaFieldError, Name};
@@ -13,6 +13,7 @@ pub mod render;
 /// Unique ID of a [`Package`]
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into, AsRef, Display)]
 #[as_ref(forward)]
+#[debug("{_0:?}")]
 pub struct Id(String);
 
 impl From<Id> for meta::Id {

--- a/moss/src/repository/mod.rs
+++ b/moss/src/repository/mod.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use derive_more::{Display, From, Into};
+use derive_more::{Debug, Display, From, Into};
 use fs_err::tokio::File;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,7 @@ pub mod manager;
 
 /// A unique [`Repository`] identifier
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, From, Display)]
+#[debug("{_0:?}")]
 #[serde(from = "String")]
 pub struct Id(String);
 

--- a/moss/src/state.rs
+++ b/moss/src/state.rs
@@ -5,13 +5,14 @@
 use std::io::Write;
 
 use chrono::{DateTime, Utc};
-use derive_more::{Display, From, Into};
+use derive_more::{Debug, Display, From, Into};
 use tui::{pretty, Styled};
 
 use crate::package;
 
 /// Unique identifier for [`State`]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, From, Into, Display)]
+#[debug("{_0:?}")]
 pub struct Id(i32);
 
 impl Id {


### PR DESCRIPTION
Debug printing one of these previously would have produced `Id("the-actual-id")`, now just `"the-actual-id"`.