### PR TITLE
moss: Improve error output for `moss index`

### DIFF
--- a/crates/stone/src/read/mod.rs
+++ b/crates/stone/src/read/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::payload::{Attribute, Compression, Index, Layout, Meta};
@@ -223,6 +224,8 @@ pub enum Error {
     PayloadDecode(#[from] payload::DecodeError),
     #[error("payload checksum mismatch: got {got:02x}, expected {expected:02x}")]
     PayloadChecksum { got: u64, expected: u64 },
+    #[error("payload checksum mismatch: got {got:02x}, expected {expected:02x}, path: {path}")]
+    PayloadCheckSumWithContext { got: u64, expected: u64, path: PathBuf },
     #[error("io")]
     Io(#[from] io::Error),
 }

--- a/moss/src/cli/mod.rs
+++ b/moss/src/cli/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{env, fs, io, path::Path, path::PathBuf};
+use std::{env, io, path::Path, path::PathBuf};
 
 use clap::{Arg, ArgAction, Command};
 use clap_complete::{
@@ -10,6 +10,7 @@ use clap_complete::{
     shells::{Bash, Fish, Zsh},
 };
 use clap_mangen::Man;
+use fs_err as fs;
 use moss::{Installation, installation, runtime};
 use thiserror::Error;
 use tracing::level_filters::LevelFilter;


### PR DESCRIPTION
- Use fs_err as fs to improve error output where it was missing
- Add stone::reader::Error variant showing the path at the call-site
  This helps identify the culprit when indexing fails due to a checksum error.
  
  NB: This is meant to be a quick-and-dirty job for now -- in production, this needs to be "nicer".