### PR TITLE
Fix reuse of clap argument ID

### DIFF
--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -61,7 +61,7 @@ pub enum Subcommand {
     },
     #[command(about = "Update a recipe file")]
     Update {
-        #[arg(long = "ver", required = true, help = "Update version")]
+        #[arg(id = "recipe_version", long = "ver", required = true, help = "Update version")]
         version: String,
         #[arg(
             short = 'u',


### PR DESCRIPTION
As of the introduction of the global --version flag, `boulder update`s --ver option was broken because it was using the same argument ID internally (when using the derives, the field name is used as the ID if not set explicitly). This makes it work again by explicitly assigning a different ID to the --ver option.

Closes #526.