### PR TITLE
github/cargo: Some compilation changes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,19 @@
+[target."x86_64-unknown-linux-gnu"]
+# - Compressing debug symbols with zstd shrinks the dev profile boulder binary from 206.03MB to 81.44MB, a 124.59MB
+# or ~60% savings. It doesn't affect the binary size for packaging builds since we strip those, but the debug symbols
+# are reduced in size from 113.16MB to 34.63MB.
+# - The new symbol mangling format (https://doc.rust-lang.org/rustc/symbol-mangling/v0.html) improves the backtrace
+# shown by RUST_BACKTRACE=1 and other debug utilities. It should also be helpful once we have ABI reports. Upstream
+# hasn't switched to it yet by default due to stable distros not having new enough tools, but that doesn't matter for us
+rustflags = [
+    "-Clink-arg=-fuse-ld=mold",
+    "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+    "-Csymbol-mangling-version=v0",
+]
+
+[target."aarch64-unknown-linux-gnu"]
+rustflags = [
+    "-Clink-arg=-fuse-ld=mold",
+    "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+    "-Csymbol-mangling-version=v0",
+]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,17 +24,17 @@ jobs:
       uses: crate-ci/typos@v1.29.3
 
     - name: Install LLVM and Clang
-      run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 18
-        echo "/usr/lib/llvm-18/bin" >> $GITHUB_PATH
-        echo "CC=/usr/lib/llvm-18/bin/clang" >> $GITHUB_ENV
+      uses: KyleMayes/install-llvm-action@v2
+      with:
+        version: "20.1"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt, clippy
+
+    - name: Install mold
+      uses: rui314/setup-mold@v1
 
     - name: Check Formatting
       run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,10 +117,9 @@ wildcard_imports = "warn"
 # has false positives in indicatif usage
 literal_string_with_formatting_args = "allow"
 
-[profile.dev]
-# makes linking faster, enables everything needed for backtraces
-# for attaching an interactive debugger, use another profile
-debug = "line-tables-only"
+# Build dependencies (but not workspace members) in release mode
+[profile.dev.package."*"]
+opt-level = 3
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ git clone https://github.com/aerynos/os-tools.git
 cd tools/
 
 # Install a few prerequisites (this how you'd do it on AerynOS)
-sudo moss it binutils glibc-devel linux-headers clang bsdtar-static cpio
+sudo moss it binutils glibc-devel linux-headers clang bsdtar-static cpio mold
 
 # remember to add ~/.cargo/bin to your $PATH if this is how you installed rustfmt
 cargo install rustfmt


### PR DESCRIPTION
Build dependencies with optimizations. Given that dependency compilation happens very infrequently this gives us most of the benefit of optimizations without increasing build times in the most common case of a developer rebuilding the project after making code changes (but not dependency changes).

Also bring back compressed debug symbols as an alternative for shrinking the binary with "line-tables-only". This shrinks the binary further than line-tables-only but without interfering with the ability to attach a debugger. To get back some of the lost linker time switch to using the mold linker.