### PR TITLE
moss: Add --check option to moss inspect command

### DIFF
--- a/crates/stone/src/read/mod.rs
+++ b/crates/stone/src/read/mod.rs
@@ -200,6 +200,16 @@ impl PayloadKind {
             None
         }
     }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            PayloadKind::Meta(_) => "Meta",
+            PayloadKind::Attributes(_) => "Attributes",
+            PayloadKind::Layout(_) => "Layout",
+            PayloadKind::Index(_) => "Index",
+            PayloadKind::Content(_) => "Content",
+        }
+    }
 }
 
 fn validate_checksum(hasher: &digest::Hasher, header: &payload::Header) -> Result<(), Error> {

--- a/moss/src/cli/inspect.rs
+++ b/moss/src/cli/inspect.rs
@@ -4,6 +4,7 @@
 
 use clap::{ArgMatches, Command, arg};
 use fs_err::File;
+use std::io::{Read, Seek, sink};
 use std::path::PathBuf;
 use stone::payload::layout;
 use stone::payload::meta;
@@ -17,6 +18,11 @@ pub fn command() -> Command {
         .about("Examine raw stone files")
         .long_about("Show detailed (debug) information on a local `.stone` file")
         .arg(arg!(<PATH> ... "files to inspect").value_parser(clap::value_parser!(PathBuf)))
+        .arg(arg!(--check "Check the integrity of the stone file(s)").action(clap::ArgAction::SetTrue))
+        .arg(
+            arg!(-q --quiet "Suppress output, only exit status indicates success or failure")
+                .action(clap::ArgAction::SetTrue),
+        )
 }
 
 ///
@@ -30,101 +36,168 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
         .cloned()
         .collect::<Vec<_>>();
 
-    // Process each input path in order.
-    for path in paths {
-        let mut file = File::open(&path)?;
-        let mut reader = stone::read(&mut file)?;
+    let check = args.get_flag("check");
+    let quiet = args.get_flag("quiet");
 
-        let header = reader.header;
-        let payloads = reader.payloads()?;
+    if check {
+        let mut had_error = false;
+        for path in paths {
+            if !quiet {
+                println!("Checking: {:?}", path.display());
+            }
 
-        // Grab the header version
-        print!("{path:?} = stone container version {:?}", header.version());
-
-        for payload in payloads.flatten() {
-            let mut layouts = vec![];
-
-            // Grab deps/providers/conflicts
-            let mut deps = vec![];
-            let mut provs = vec![];
-            let mut cnfls = vec![];
-
-            match payload {
-                PayloadKind::Layout(l) => layouts = l.body,
-                PayloadKind::Meta(meta) => {
-                    println!();
-
-                    for record in meta.body {
-                        let name = format!("{:?}", record.tag);
-
-                        match &record.kind {
-                            meta::Kind::Provider(k, p) if record.tag == meta::Tag::Provides => {
-                                provs.push(format!("{k}({p})"));
-                            }
-                            meta::Kind::Provider(k, p) if record.tag == meta::Tag::Conflicts => {
-                                cnfls.push(format!("{k}({p})"));
-                            }
-                            meta::Kind::Dependency(k, d) => {
-                                deps.push(format!("{k}({d})"));
-                            }
-                            meta::Kind::String(s) => {
-                                println!("{name:COLUMN_WIDTH$} : {s}");
-                            }
-                            meta::Kind::Int64(i) => {
-                                println!("{name:COLUMN_WIDTH$} : {i}");
-                            }
-                            meta::Kind::Uint64(i) => {
-                                println!("{name:COLUMN_WIDTH$} : {i}");
-                            }
-                            _ => {
-                                println!("{name:COLUMN_WIDTH$} : {record:?}");
-                            }
+            match File::open(&path).map_err(Error::IO).and_then(check_stone_integrity) {
+                Ok(payload_kinds) => {
+                    if !quiet {
+                        for kind in payload_kinds {
+                            println!("  OK: {kind}");
                         }
+                        println!("Result: OK\n");
                     }
                 }
-                _ => {}
-            }
-
-            if !deps.is_empty() {
-                println!("\n{:COLUMN_WIDTH$} :", "Dependencies");
-                for dep in deps {
-                    println!("    - {dep}");
-                }
-            }
-            if !provs.is_empty() {
-                println!("\n{:COLUMN_WIDTH$} :", "Providers");
-                for prov in provs {
-                    println!("    - {prov}");
-                }
-            }
-            if !cnfls.is_empty() {
-                println!("\n{:COLUMN_WIDTH$} :", "Conflicts");
-                for cnfl in cnfls {
-                    println!("    - {cnfl}");
-                }
-            }
-
-            if !layouts.is_empty() {
-                println!("\n{:COLUMN_WIDTH$} :", "Layout entries");
-                for layout in layouts {
-                    match layout.entry {
-                        layout::Entry::Regular(hash, target) => {
-                            println!("    - /usr/{target} - [Regular] {hash:032x}");
-                        }
-                        layout::Entry::Directory(target) => {
-                            println!("    - /usr/{target} [Directory]");
-                        }
-                        layout::Entry::Symlink(source, target) => {
-                            println!("    - /usr/{target} -> {source} [Symlink]");
-                        }
-                        _ => unreachable!(),
-                    };
+                Err(e) => {
+                    had_error = true;
+                    if !quiet {
+                        println!("Result: FAILED - {e}\n");
+                    }
                 }
             }
         }
+
+        if had_error {
+            Err(Error::ValidationFailed)
+        } else {
+            Ok(())
+        }
+    } else {
+        // Process each input path in order.
+        for path in paths {
+            let mut file = File::open(&path)?;
+            let mut reader = stone::read(&mut file)?;
+
+            let header = reader.header;
+            let payloads = reader.payloads()?;
+
+            // Grab the header version
+            print!("{path:?} = stone container version {:?}", header.version());
+
+            for payload in payloads.flatten() {
+                let mut layouts = vec![];
+
+                // Grab deps/providers/conflicts
+                let mut deps = vec![];
+                let mut provs = vec![];
+                let mut cnfls = vec![];
+
+                match payload {
+                    PayloadKind::Layout(l) => layouts = l.body,
+                    PayloadKind::Meta(meta) => {
+                        println!();
+
+                        for record in meta.body {
+                            let name = format!("{:?}", record.tag);
+
+                            match &record.kind {
+                                meta::Kind::Provider(k, p) if record.tag == meta::Tag::Provides => {
+                                    provs.push(format!("{k}({p})"));
+                                }
+                                meta::Kind::Provider(k, p) if record.tag == meta::Tag::Conflicts => {
+                                    cnfls.push(format!("{k}({p})"));
+                                }
+                                meta::Kind::Dependency(k, d) => {
+                                    deps.push(format!("{k}({d})"));
+                                }
+                                meta::Kind::String(s) => {
+                                    println!("{name:COLUMN_WIDTH$} : {s}");
+                                }
+                                meta::Kind::Int64(i) => {
+                                    println!("{name:COLUMN_WIDTH$} : {i}");
+                                }
+                                meta::Kind::Uint64(i) => {
+                                    println!("{name:COLUMN_WIDTH$} : {i}");
+                                }
+                                _ => {
+                                    println!("{name:COLUMN_WIDTH$} : {record:?}");
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+
+                if !deps.is_empty() {
+                    println!("\n{:COLUMN_WIDTH$} :", "Dependencies");
+                    for dep in deps {
+                        println!("    - {dep}");
+                    }
+                }
+                if !provs.is_empty() {
+                    println!("\n{:COLUMN_WIDTH$} :", "Providers");
+                    for prov in provs {
+                        println!("    - {prov}");
+                    }
+                }
+                if !cnfls.is_empty() {
+                    println!("\n{:COLUMN_WIDTH$} :", "Conflicts");
+                    for cnfl in cnfls {
+                        println!("    - {cnfl}");
+                    }
+                }
+
+                if !layouts.is_empty() {
+                    println!("\n{:COLUMN_WIDTH$} :", "Layout entries");
+                    for layout in layouts {
+                        match layout.entry {
+                            layout::Entry::Regular(hash, target) => {
+                                println!("    - /usr/{target} - [Regular] {hash:032x}");
+                            }
+                            layout::Entry::Directory(target) => {
+                                println!("    - /usr/{target} [Directory]");
+                            }
+                            layout::Entry::Symlink(source, target) => {
+                                println!("    - /usr/{target} -> {source} [Symlink]");
+                            }
+                            _ => unreachable!(),
+                        };
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Checks the integrity of a single .stone file by reading all payloads
+/// and validating their checksums from any readable source.
+fn check_stone_integrity(mut source: impl Read + Seek) -> Result<Vec<String>, Error> {
+    let mut reader = stone::read(&mut source)?;
+    let mut found_payloads = Vec::new();
+
+    // The `collect` call forces the iterator to run, which in turn decodes
+    // each payload and validates its checksum as a side-effect.
+    let payloads = reader.payloads()?.collect::<Result<Vec<_>, _>>()?;
+
+    // Find the content payload, if it exists.
+    let content_payload = payloads.iter().find_map(PayloadKind::content);
+
+    // Explicitly unpack the content payload to a null sink to validate its checksum.
+    if let Some(content) = content_payload {
+        reader.unpack_content(content, &mut sink())?;
     }
 
-    Ok(())
+    // Collect the names of found payloads for reporting.
+    for p in payloads {
+        let name = match p {
+            PayloadKind::Meta(_) => "Meta",
+            PayloadKind::Attributes(_) => "Attributes",
+            PayloadKind::Layout(_) => "Layout",
+            PayloadKind::Index(_) => "Index",
+            PayloadKind::Content(_) => "Content",
+        };
+        found_payloads.push(name.to_owned());
+    }
+
+    Ok(found_payloads)
 }
 
 #[derive(Debug, Error)]
@@ -134,4 +207,67 @@ pub enum Error {
 
     #[error("stone format")]
     Format(#[from] stone::read::Error),
+
+    #[error("One or more files failed the integrity check")]
+    ValidationFailed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    const VALID_STONE_BYTES: &[u8] = include_bytes!("../../../test/bash-completion-2.11-1-1-x86_64.stone");
+
+    #[test]
+    fn test_check_valid_stone() {
+        let source = Cursor::new(VALID_STONE_BYTES);
+        let result = check_stone_integrity(source);
+        assert!(result.is_ok(), "Check should pass for a valid stone file");
+
+        let payloads = result.unwrap();
+        assert!(payloads.contains(&"Meta".to_owned()));
+        assert!(payloads.contains(&"Layout".to_owned()));
+        assert!(payloads.contains(&"Index".to_owned()));
+        assert!(payloads.contains(&"Content".to_owned()));
+    }
+
+    #[test]
+    fn test_check_corrupted_stone() {
+        let mut corrupted_bytes = VALID_STONE_BYTES.to_vec();
+
+        // Corrupt a byte in the middle of the file to trigger corruption detection.
+        let mid = corrupted_bytes.len() / 2;
+        corrupted_bytes[mid] = corrupted_bytes[mid].wrapping_add(1);
+
+        let source = Cursor::new(corrupted_bytes);
+        let result = check_stone_integrity(source);
+
+        assert!(result.is_err(), "Check should fail for a corrupted stone file");
+
+        // Any corruption should be detected - could be checksum mismatch or data corruption
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, Error::Format(stone::read::Error::PayloadChecksum { .. }))
+                || matches!(err, Error::Format(stone::read::Error::Io(_))),
+            "Error should be corruption-related, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_check_malformed_stone() {
+        // Use garbage data that doesn't even have a valid header.
+        let malformed_bytes = b"this is not a stone file";
+        let source = Cursor::new(malformed_bytes);
+        let result = check_stone_integrity(source);
+
+        assert!(result.is_err(), "Check should fail for malformed data");
+
+        // Check for a header decoding error.
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, Error::Format(stone::read::Error::HeaderDecode(_))),
+            "Error should be a header decode error"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `--check` option to the `moss inspect` command to verify the integrity of .stone files.

## Changes

- Added `--check` flag to enable integrity checking mode
- Added `--quiet` flag for suppressed output
- Implemented `check_stone_integrity()` helper function
- Exit 0 if all files pass integrity checks
- Exit 1 if any file fails validation
- Added test coverage for valid, corrupted, and malformed stone files

## Usage

```bash
# Check integrity of a single stone file
moss inspect --check some.stone

# Check multiple files quietly
moss inspect --check --quiet file1.stone file2.stone
```

Closes #517