### PR TITLE
boulder: Disallow git tags and branches in upstreams to ensure reproducible builds

### DIFF
--- a/crates/stone_recipe/src/lib.rs
+++ b/crates/stone_recipe/src/lib.rs
@@ -22,6 +22,16 @@ fn is_valid_sha1(s: &str) -> bool {
     s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
+fn format_git_ref_error(ref_id: &str) -> String {
+    format!(
+        "{} '{ref_id}'.",
+        "Using git tags or branches in upstreams is disallowed. \
+This helps ensure reproducibility since git tags and branches are mutable \
+references that can be updated to point to different commits over time. \
+Please use the full 40-character commit SHA instead of"
+    )
+}
+
 pub fn from_slice(bytes: &[u8]) -> Result<Recipe, Error> {
     serde_yaml::from_slice(bytes)
 }
@@ -191,16 +201,12 @@ impl<'de> Deserialize<'de> for Upstream {
         struct UriParseError(#[from] url::ParseError);
 
         // Helper function to validate the ref_id for git type upstreams to ensure it is a valid SHA1 hash.
-        // This helps ensure reproducibility since git tags and branches are mutable references that can be updated to point to different commits over time.
         fn validate_ref_id<'de, D>(ref_id: &str) -> Result<(), D::Error>
         where
             D: serde::Deserializer<'de>,
         {
             if !is_valid_sha1(ref_id) {
-                return Err(serde::de::Error::custom(format!(
-                    "Using git tags or branches in upstreams is disallowed for reproducibility. Please use the full 40-character commit SHA instead of '{}'.",
-                    ref_id
-                )));
+                return Err(serde::de::Error::custom(format_git_ref_error(ref_id)));
             }
             Ok(())
         }
@@ -422,9 +428,9 @@ upstreams:
 "#;
         let result = from_str(input);
         assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("Using git tags or branches in upstreams is disallowed for reproducibility."));
-        assert!(err_msg.contains("Please use the full 40-character commit SHA instead of 'v1.0.0'."));
+        let formatted_msg = format_git_ref_error("v1.0.0");
+        let actual_msg = result.unwrap_err().to_string();
+        assert!(actual_msg.contains(&formatted_msg));
     }
 
     #[test]

--- a/crates/stone_recipe/src/lib.rs
+++ b/crates/stone_recipe/src/lib.rs
@@ -18,6 +18,10 @@ pub mod macros;
 pub mod script;
 pub mod tuning;
 
+fn is_valid_sha1(s: &str) -> bool {
+    s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
 pub fn from_slice(bytes: &[u8]) -> Result<Recipe, Error> {
     serde_yaml::from_slice(bytes)
 }
@@ -186,6 +190,21 @@ impl<'de> Deserialize<'de> for Upstream {
         #[error("invalid uri: {0}")]
         struct UriParseError(#[from] url::ParseError);
 
+        // Helper function to validate the ref_id for git type upstreams to ensure it is a valid SHA1 hash.
+        // This helps ensure reproducibility since git tags and branches are mutable references that can be updated to point to different commits over time.
+        fn validate_ref_id<'de, D>(ref_id: &str) -> Result<(), D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            if !is_valid_sha1(ref_id) {
+                return Err(serde::de::Error::custom(format!(
+                    "Using git tags or branches in upstreams is disallowed for reproducibility. Please use the full 40-character commit SHA instead of '{}'.",
+                    ref_id
+                )));
+            }
+            Ok(())
+        }
+
         let raw_map = BTreeMap::<Uri, Outer>::deserialize(deserializer)?;
 
         match raw_map.into_iter().next() {
@@ -197,12 +216,15 @@ impl<'de> Deserialize<'de> for Upstream {
                 unpack: default_true(),
                 unpack_dir: None,
             }),
-            Some((Uri::Git(uri), Outer::String(ref_id))) => Ok(Upstream::Git {
-                uri,
-                ref_id,
-                clone_dir: None,
-                staging: default_true(),
-            }),
+            Some((Uri::Git(uri), Outer::String(ref_id))) => {
+                validate_ref_id::<D>(&ref_id)?;
+                Ok(Upstream::Git {
+                    uri,
+                    ref_id,
+                    clone_dir: None,
+                    staging: default_true(),
+                })
+            }
             Some((
                 Uri::Plain(uri),
                 Outer::Inner(Inner::Plain {
@@ -227,12 +249,15 @@ impl<'de> Deserialize<'de> for Upstream {
                     clone_dir,
                     staging,
                 }),
-            )) => Ok(Upstream::Git {
-                uri,
-                ref_id,
-                clone_dir,
-                staging,
-            }),
+            )) => {
+                validate_ref_id::<D>(&ref_id)?;
+                Ok(Upstream::Git {
+                    uri,
+                    ref_id,
+                    clone_dir,
+                    staging,
+                })
+            }
             Some((Uri::Plain(_), Outer::Inner(Inner::Git { .. }))) => Err(serde::de::Error::custom(
                 "found git payload but missing 'git|' prefixed URI",
             )),
@@ -382,5 +407,38 @@ mod test {
             let recipe = from_slice(input).unwrap();
             dbg!(&recipe);
         }
+    }
+
+    #[test]
+    fn reject_git_tag() {
+        let input = r#"
+name: test-pkg
+version: 1.0.0
+release: 1
+license: MIT
+homepage: https://example.com
+upstreams:
+    - git|https://github.com/example/repo : v1.0.0
+"#;
+        let result = from_str(input);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Using git tags or branches in upstreams is disallowed for reproducibility."));
+        assert!(err_msg.contains("Please use the full 40-character commit SHA instead of 'v1.0.0'."));
+    }
+
+    #[test]
+    fn accept_git_sha() {
+        let input = r#"
+name: test-pkg
+version: 1.0.0
+release: 1
+license: MIT
+homepage: https://example.com
+upstreams:
+    - git|https://github.com/example/repo : 85f8339d9c11caa203d79e6b10fd928a388d6466
+"#;
+        let result = from_str(input);
+        assert!(result.is_ok());
     }
 }

--- a/test/boulder-stone.yml
+++ b/test/boulder-stone.yml
@@ -8,7 +8,7 @@ description : |
     Extremely flexible and powerful, yet simple to use, package build
     tool for the Serpent OS project.
 upstreams   :
-    - git|https://github.com/serpent-os/boulder : v1.0.1
+    - git|https://github.com/serpent-os/boulder : 85f8339d9c11caa203d79e6b10fd928a388d6466
     - https://github.com/serpent-os/libmoss/releases/download/v1.2.0/libmoss-1.2.0.tar.xz:
         hash: cbf684b5a37a3a433e0526beb04a7b3419b71e81b3709c3b0d7ed6a1987d3dcb
         unpackdir: libmoss


### PR DESCRIPTION
Closes #109 

Hopefully this is close to what the thinking was. I've placed the error formatting function at the module level for easy maintenance and reuse in tests. Let me know if you'd prefer a different location. And I'm certainly open to feedback on the exact messaging for the error. 