### PR TITLE
boulder: Add 7z

### DIFF
--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -156,6 +156,9 @@ fn packages(builder: &Builder) -> Vec<&str> {
                     "tgz" => {
                         packages.push("binary(bsdtar-static)");
                     }
+                    "7z" => {
+                        packages.push("binary(bsdtar-static)");
+                    }
                     "zip" => {
                         packages.push("binary(bsdtar-static)");
                     }


### PR DESCRIPTION
Ensure that bsdtar-static gets installed to handle source.7z archives.