### PR TITLE
boulder: Improve build header

### DIFF
--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -73,6 +73,12 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
     }
 
     let builder = Builder::new(&recipe_path, env, profile, ccache, output)?;
+    let pkg_name = format!(
+        "{}-{}-{}",
+        builder.recipe.parsed.source.name, builder.recipe.parsed.source.version, builder.recipe.parsed.source.release
+    );
+    println!("boulder {}", tools_buildinfo::get_simple_version());
+    println!("└─ building {pkg_name}-{build_release}\n");
     builder.setup(&mut timing, timer, update)?;
 
     let paths = &builder.paths;
@@ -86,11 +92,6 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
             ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Batch),
         )?;
     }
-
-    let pkg_name = format!(
-        "{}-{}-{}",
-        builder.recipe.parsed.source.name, builder.recipe.parsed.source.version, builder.recipe.parsed.source.release
-    );
 
     // hold a fd
     let _fd = inhibit(

--- a/crates/tools_buildinfo/src/lib.rs
+++ b/crates/tools_buildinfo/src/lib.rs
@@ -101,9 +101,9 @@ pub fn get_simple_version() -> String {
     format!("v{}{git}", values::VERSION)
 }
 
-/// For git builds this returns a string like `v0.1.0 (git 4ecad5d7e70c2cdc81350dc6b46fb55b1ccb18f5-dirty)`
+/// For git builds this returns a string like `version v0.1.0 (git 4ecad5d7e70c2cdc81350dc6b46fb55b1ccb18f5-dirty) (Built at 2025-07-09T19:20:40+00:00)`
 ///
-/// For builds from a non-git source just the version will be returned: `v0.1.0`
+/// For builds from a non-git source just the version will be returned: `version v0.1.0 (Built at 2025-07-09T19:20:40+00:00)`
 pub fn get_full_version() -> String {
     let git = if cfg!(BUILDINFO_IS_GIT_BUILD) {
         format!(" (Git ref {}{})", get_git_full_hash(), get_git_dirty())


### PR DESCRIPTION
## Summary of Changes

- Display boulder version at start of build
- Show package name, version, source release, and build release being built
- Correct `get_full_version()` documentation to match actual output format

## Example Output

before:

```bash
The following package(s) will be installed:

...
```

after:

```bash
boulder v0.25.6 (Git ref b2558d8445fd8ca3eff90165981adaa7730a3921-dirty)
└─ building llvm-16.0.4-8-1

The following package(s) will be installed:

...
```

Closes #460 
