### PR TITLE
boulder: improve boulder new error handling for `boulder new`

### DIFF
--- a/boulder/src/draft/monitoring.rs
+++ b/boulder/src/draft/monitoring.rs
@@ -84,7 +84,7 @@ impl<'a> Monitoring<'a> {
                         .status()
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| "unknown".to_owned());
-                    println!("{} | Monitoring service returned error: {status}", "Warning".yellow(),);
+                    println!("{} | Monitoring service returned error: {status}", "Warning".yellow());
                     Response {
                         items: Vec::new(),
                         total_items: 0,
@@ -93,7 +93,7 @@ impl<'a> Monitoring<'a> {
             },
             Err(_) => {
                 // request error, maybe site is inaccessible?
-                println!("{} | Monitoring service is inaccessible", "Warning".yellow(),);
+                println!("{} | Monitoring service is inaccessible", "Warning".yellow());
                 Response {
                     items: Vec::new(),
                     total_items: 0,
@@ -157,13 +157,13 @@ impl<'a> Monitoring<'a> {
                         .status()
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| "unknown".to_owned());
-                    println!("{} | CPE service returned an error: {status}", "Warning".yellow(),);
+                    println!("{} | CPE service returned an error: {status}", "Warning".yellow());
                     (Vec::new(), "service_error")
                 }
             },
             Err(_) => {
                 // request error, maybe site is inaccessible?
-                println!("{} | CPE service is inaccessible", "Warning".yellow(),);
+                println!("{} | CPE service is inaccessible", "Warning".yellow());
                 (Vec::new(), "connection_failed")
             }
         };
@@ -258,15 +258,15 @@ impl<'a> Monitoring<'a> {
             yaml_string = yaml_string.replace(cpe_string, "cpe: ~");
             let cpe_help_text = match cpe_search_status.as_str() {
                 "service_error" => format!(
-                    " # CPE service returned error, retry later {}",
+                    " # CPE service returned error, retry later ({})",
                     chrono::Local::now().date_naive().format("%Y-%m-%d")
                 ),
                 "connection_failed" => format!(
-                    " # CPE service unreachable, retry later {}",
+                    " # CPE service unreachable, retry later ({})",
                     chrono::Local::now().date_naive().format("%Y-%m-%d")
                 ),
                 _ => format!(
-                    " # No CPE found, last checked {}",
+                    " # No CPE found, last checked ({})",
                     chrono::Local::now().date_naive().format("%Y-%m-%d")
                 ),
             };


### PR DESCRIPTION
Closes #511 

## Summary of Changes

- For requests to release-monitoring.org and cpe-guesser.cve-search.org, HTTP errors and connection failures now show warnings and continue with empty response instead of crashing
- Informative comments included in the `monitoring.yaml` based on failure type for CPE failures:
  - Service errors: `# CPE service returned error, retry later <date>`
  - Connection failed: `# CPE service unreachable, retry later <date>`
  - No results: `# No CPE found, last checked <date>`

I've tested this by blocking access to the sites and running boulder new on the abseil-cpp project:

```bash
boulder new https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz
```

With release-monitoring.org inaccessible:

```bash
 ■ Extracting https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz                               Detected type: application/gzip (gz)
Fetched https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz

Warning | Monitoring service is inaccessible
Warning | Find the correct ID for the project at https://release-monitoring.org/

Saved stone.yaml & monitoring.yaml to "."
```

```yml
releases:
  id: ~ # https://release-monitoring.org/ and use the numeric id in the url of project
  rss: https://github.com/abseil/abseil-cpp/releases.atom
security:
  cpe: ~ # No CPE found, last checked 2025-08-09
```

With cpe-guesser.cve-search.org inaccessible:

```bash
 ■ Extracting https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz                               Detected type: application/gzip (gz)
Fetched https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz

Monitoring | Matched id 115295 from abseil-cpp
Warning | CPE service is inaccessible

Saved stone.yaml & monitoring.yaml to "."
```

```yml
releases:
  id: 115295
  rss: https://github.com/abseil/abseil-cpp/releases.atom
security:
  cpe: ~ # CPE service unreachable, retry later 2025-08-09
```