### PR TITLE
boulder: Add %export_docbook_catalogs misc action

### DIFF
--- a/boulder/data/macros/actions/misc.yaml
+++ b/boulder/data/macros/actions/misc.yaml
@@ -1,5 +1,13 @@
 actions:
 
+    - export_docbook_catalogs:
+        description: Ensure that builds using docbook can find XML catalogs locally
+        example: |
+            environment : |
+                %export_docbook_catalogs
+        command: |
+            export XML_CATALOG_FILES=\"$(find /usr/share/defaults/docbook -type f -name 'catalog' -exec echo -e 'file://{} ' \;)\"
+
     - gtk_update_icon_cache:
         description: Pregenerate icon cache at build time
         example: |

--- a/boulder/data/macros/actions/misc.yaml
+++ b/boulder/data/macros/actions/misc.yaml
@@ -16,7 +16,7 @@ actions:
         example: |
             %install_bin nano
         command: |
-            install -Dm00755 -t %(installroot)/%(bindir)
+            install -Dm00755 -t %(installroot)%(bindir)
 
     - install_dir:
         description: Create a new empty directory with the default permissions
@@ -27,22 +27,24 @@ actions:
 
     - install_exe:
         description: Macro to install a file with default executable permissions
+        example: |
+            %install_exe executable-file %(installroot)%(libexec)/%(name)/executable-file
         command: |
             install -Dm00755
 
     - install_file:
         description: Macro to install a file without executable permissions
         example: |
-            %install_file %(pkgdir)/helper.file %(installroot)%(datadir)/pkgname/pkgfile
+            %install_file %(pkgdir)/helper.file %(installroot)%(datadir)/%(name)/pkgfile
         command: |
             install -Dm00644
 
     - patch:
         description: Patch the upstream sources using an input patch file.
         example: |
-            %patch %(pkgdir)/${file}
+            %patch %(pkgdir)/some.patch
 
-            # If you need to override -p#, add it after ${file}
+            # If you need to override the default -p1, add it after the patch file
             %patch %(pkgdir)/some.patch -p3
         command: |
             patch -f -p1 -i
@@ -54,8 +56,8 @@ actions:
         command: |
             create_tmpfiles(){
                 if [ -z "%(libsuffix)" ]; then
-                    mkdir -p %(installroot)/%(tmpfilesdir)
-                    echo "$@" >> %(installroot)/%(tmpfilesdir)/%(name).conf
+                    mkdir -p %(installroot)%(tmpfilesdir)
+                    echo "$@" >> %(installroot)%(tmpfilesdir)/%(name).conf
                 fi
             }
             create_tmpfiles
@@ -65,8 +67,8 @@ actions:
         command: |
             create_sysusers(){
                 if [ -z "%(libsuffix)" ]; then
-                    mkdir -p %(installroot)/%(sysusersdir)
-                    echo "$@" >> %(installroot)/%(sysusersdir)/%(name).conf
+                    mkdir -p %(installroot)%(sysusersdir)
+                    echo "$@" >> %(installroot)%(sysusersdir)/%(name).conf
                 fi
             }
             create_sysusers


### PR DESCRIPTION
Autodiscovers installed docbook catalogs for local use in builds that
require docbook to build documentation.

The action is intended to be used like so:

```yaml
(...)
builddeps  :
    - (...)
    - docbook
    - docbook-xsl
    - docbook-(...)
    - (...)
environment: |
    %export_docbook_catalogs
(...)
```

**Test Plan**:

- build new boulder with `just get-started`
- use that boulder to build gtk-3 with:
  ```
    environment: |
        %export_docbook_catalogs
  ```
- observe the following output:
  ```
  │S│ The work directory %(workdir) is /mason/build/x86_64/gtk-3.24.50.tar.xz
  │S│ ++ find /usr/share/defaults/docbook -type f -name catalog -exec echo -e 'file://{} ' ';'
  │S│ + export 'XML_CATALOG_FILES="file:///usr/share/defaults/docbook/docbook-dtd/catalog 
  │S│ file:///usr/share/defaults/docbook/docbook-xsl/catalog "'
  │S│ + XML_CATALOG_FILES='"file:///usr/share/defaults/docbook/docbook-dtd/catalog 
  │S│ file:///usr/share/defaults/docbook/docbook-xsl/catalog "'
  ```