### PR TITLE
Boulder: Refactor boulder git hash resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "stone",
  "stone_recipe",
  "strum",
+ "tempfile",
  "thiserror 2.0.12",
  "thread-priority",
  "tokio",
@@ -2885,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ zstd = { version = "0.13.2", features = ["zstdmt"] }
 mailparse = "0.15.0"
 zbus = "5.1.1"
 infer = "0.19.0"
+tempfile = "3.20.0"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -45,5 +45,8 @@ mailparse.workspace = true
 infer.workspace = true
 zstd.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -60,8 +60,6 @@ impl Builder {
     ) -> Result<Self, Error> {
         let recipe = Recipe::load(recipe_path)?;
 
-        git::update_git_upstream_refs(&recipe, recipe_path)?;
-
         let macros = Macros::load(&env)?;
 
         let paths = Paths::new(&recipe, &env.cache_dir, "/mason", output_dir)?;

--- a/boulder/src/build/git.rs
+++ b/boulder/src/build/git.rs
@@ -247,6 +247,16 @@ upstreams:
             .args(["init"])
             .output()
             .unwrap();
+        Command::new("git")
+            .current_dir(temp_dir.path())
+            .args(["config", "user.email", "test@test.com"])
+            .output()
+            .unwrap();
+        Command::new("git")
+            .current_dir(temp_dir.path())
+            .args(["config", "user.name", "Test"])
+            .output()
+            .unwrap();
 
         // Create the first commit
         fs::write(temp_dir.path().join("file"), "content").unwrap();

--- a/boulder/src/build/git.rs
+++ b/boulder/src/build/git.rs
@@ -75,16 +75,23 @@ pub(crate) fn update_git_upstream_refs(
     let mut yaml_updater = yaml::Updater::new();
     let mut refs_updated = false;
 
-    for (index, installed) in installed_upstreams.iter().enumerate() {
+    for installed in installed_upstreams.iter() {
         if let Installed::Git {
             uri,
             original_ref,
             resolved_hash,
+            original_index,
             ..
         } = installed
         {
             if resolved_hash != original_ref {
-                update_git_upstream_ref_in_yaml(&mut yaml_updater, index, uri.as_str(), resolved_hash, original_ref);
+                update_git_upstream_ref_in_yaml(
+                    &mut yaml_updater,
+                    *original_index,
+                    uri.as_str(),
+                    resolved_hash,
+                    original_ref,
+                );
                 println!(
                     "{} | Updated ref '{original_ref}' to commit {} for {uri}",
                     "Warning".yellow(),
@@ -139,6 +146,7 @@ upstreams:
                 uri: Url::parse("https://github.com/example/repo1.git").unwrap(),
                 original_ref: "main".to_string(),
                 resolved_hash: "1111222233334444555566667777888899990000".to_string(),
+                original_index: 0,
             },
             Installed::Git {
                 name: "repo2.git".to_string(),
@@ -147,6 +155,7 @@ upstreams:
                 uri: Url::parse("https://github.com/example/repo2.git").unwrap(),
                 original_ref: "main".to_string(),
                 resolved_hash: "aaaa1111bbbb2222cccc3333dddd4444eeee5555".to_string(),
+                original_index: 1,
             },
             Installed::Git {
                 name: "repo3.git".to_string(),
@@ -155,6 +164,7 @@ upstreams:
                 uri: Url::parse("https://github.com/example/repo3.git").unwrap(),
                 original_ref: "abcd1234567890abcdef1234567890abcdef1234".to_string(),
                 resolved_hash: "abcd1234567890abcdef1234567890abcdef1234".to_string(),
+                original_index: 2,
             },
             Installed::Git {
                 name: "repo4.git".to_string(),
@@ -163,6 +173,7 @@ upstreams:
                 uri: Url::parse("https://github.com/example/repo4.git").unwrap(),
                 original_ref: "abc123d".to_string(),
                 resolved_hash: "abc123d567890abcdef1234567890abcdef12345".to_string(),
+                original_index: 3,
             },
             Installed::Plain {
                 name: "file.tar.gz".to_string(),
@@ -212,6 +223,7 @@ upstreams:
                 uri: Url::parse("https://github.com/example/repo3.git").unwrap(),
                 original_ref: "abcd1234567890abcdef1234567890abcdef1234".to_string(),
                 resolved_hash: "abcd1234567890abcdef1234567890abcdef1234".to_string(),
+                original_index: 0,
             },
             Installed::Plain {
                 name: "file.tar.gz".to_string(),

--- a/boulder/src/build/upstream.rs
+++ b/boulder/src/build/upstream.rs
@@ -19,10 +19,10 @@ use tokio::io::AsyncWriteExt;
 use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
 use url::Url;
 
-use crate::{Paths, Recipe, util};
+use crate::{Paths, Recipe, build::git, util};
 
-/// Cache all upstreams from the provided [`Recipe`] and make them available
-/// in the guest rootfs.
+/// Cache all upstreams from the provided [`Recipe`], make them available
+/// in the guest rootfs, and update the stone.yaml with resolved git upstream hashes.
 pub fn sync(recipe: &Recipe, paths: &Paths) -> Result<(), Error> {
     let upstreams = recipe
         .parsed
@@ -48,7 +48,7 @@ pub fn sync(recipe: &Recipe, paths: &Paths) -> Result<(), Error> {
     let upstream_dir = paths.guest_host_path(&paths.upstreams());
     util::ensure_dir_exists(&upstream_dir)?;
 
-    runtime::block_on(
+    let installed_upstreams = runtime::block_on(
         stream::iter(&upstreams)
             .map(|upstream| async {
                 let pb = mp.insert_before(
@@ -87,11 +87,19 @@ pub fn sync(recipe: &Recipe, paths: &Paths) -> Result<(), Error> {
                 mp.suspend(|| println!("{} {}{cached_tag}", "Shared".green(), upstream.name().bold()));
                 tp.inc(1);
 
-                Ok(()) as Result<_, Error>
+                Ok(install) as Result<_, Error>
             })
             .buffer_unordered(moss::environment::MAX_NETWORK_CONCURRENCY)
-            .try_collect::<()>(),
+            .try_collect::<Vec<_>>(),
     )?;
+
+    if let Some(updated_yaml) = git::update_git_upstream_refs(&recipe.source, &installed_upstreams)? {
+        fs::write(&recipe.path, updated_yaml)?;
+        println!(
+            "{} | Git references resolved to commit hashes and saved to stone.yaml. This ensures reproducible builds since tags and branches can move over time.",
+            "Warning".yellow()
+        );
+    }
 
     mp.clear()?;
     println!();
@@ -100,7 +108,7 @@ pub fn sync(recipe: &Recipe, paths: &Paths) -> Result<(), Error> {
 }
 
 #[derive(Clone)]
-enum Installed {
+pub(crate) enum Installed {
     Plain {
         name: String,
         path: PathBuf,
@@ -110,6 +118,9 @@ enum Installed {
         name: String,
         path: PathBuf,
         was_cached: bool,
+        uri: Url,
+        original_ref: String,
+        resolved_hash: String,
     },
 }
 
@@ -357,10 +368,20 @@ impl Git {
 
         if self.ref_exists(&final_path).await? {
             self.reset_to_ref(&final_path).await?;
+            let resolved_hash = runtime::unblock({
+                let final_path = final_path.clone();
+                let ref_id = self.ref_id.clone();
+                let uri = self.uri.clone();
+                move || git::resolve_git_ref(&final_path, &ref_id, &uri)
+            })
+            .await?;
             return Ok(Installed::Git {
                 name: self.name().to_owned(),
                 path: final_path,
                 was_cached: true,
+                uri: self.uri.clone(),
+                original_ref: self.ref_id.clone(),
+                resolved_hash,
             });
         }
 
@@ -384,10 +405,21 @@ impl Git {
 
         self.reset_to_ref(&final_path).await?;
 
+        let resolved_hash = runtime::unblock({
+            let final_path = final_path.clone();
+            let ref_id = self.ref_id.clone();
+            let uri = self.uri.clone();
+            move || git::resolve_git_ref(&final_path, &ref_id, &uri)
+        })
+        .await?;
+
         Ok(Installed::Git {
             name: self.name().to_owned(),
             path: final_path,
             was_cached: false,
+            uri: self.uri.clone(),
+            original_ref: self.ref_id.clone(),
+            resolved_hash,
         })
     }
 
@@ -460,4 +492,6 @@ pub enum Error {
     Request(#[from] moss::request::Error),
     #[error("io")]
     Io(#[from] io::Error),
+    #[error("git")]
+    Git(#[from] git::GitError),
 }


### PR DESCRIPTION
Per discussion on matrix, this refactors git upstream hash resolution to use `git rev-parse` on cloned repositories instead of `git ls-remote` during build initialization.

This is a backwards compatible change but should allow for more flexibility in the `ref` specified in the `stone.yaml`. In particular any ref or hash that `git rev-parse` can parse should resolve to the full 40 character hash.

I've include a suite of tests for both the new `resolve_git_ref` and `update_git_upstream_refs` that test various refs and hashes in different formats. I think it is comprehensive enough, but let me know if you see any obvious holes.
