### PR TITLE
boulder: Change recipe template to © AerynOS

### DIFF
--- a/boulder/data/recipeTemplate.yaml
+++ b/boulder/data/recipeTemplate.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: © 2020-2025 AerynOS Developers
+# SPDX-FileCopyrightText: © 2025- AerynOS Developers
 #
 # SPDX-License-Identifier: MPL-2.0
 #

--- a/boulder/src/draft.rs
+++ b/boulder/src/draft.rs
@@ -91,7 +91,7 @@ impl Drafter {
         #[rustfmt::skip]
         let template = format!(
 "#
-# SPDX-FileCopyrightText: © 2020-2025 Serpent OS Developers
+# SPDX-FileCopyrightText: © 2025- AerynOS Developers
 #
 # SPDX-License-Identifier: MPL-2.0
 #


### PR DESCRIPTION
This change is somewhat long overdue.