### PR TITLE
boulder: Adjust patch again

### DIFF
--- a/boulder/data/macros/actions/misc.yaml
+++ b/boulder/data/macros/actions/misc.yaml
@@ -55,7 +55,7 @@ actions:
             # If you need to override the default -p1, add it after the patch file
             %patch %(pkgdir)/some.patch -p3
         command: |
-            patch --batch --remove-empty-files --no-backup-if-mismatch -p1 -i
+            patch --force --forward --remove-empty-files --no-backup-if-mismatch -p1 -i
         dependencies:
             - binary(patch)
 


### PR DESCRIPTION
The previous flags didn't _quite_ do what I wanted, so switch `--batch` back to `--force` so that patch won't attempt to reverse patches that have already been flagged. The `--forward` flag does the same thing and is technically redundant with `--force` but it makes it clear what patch should be doing.