### PR TITLE
moss: Add tracing to sync command

### DIFF
--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -17,7 +17,7 @@ use moss::{
 };
 use thiserror::Error;
 
-use tracing::{debug, info, info_span, instrument};
+use tracing::{Instrument, debug, info, info_span, instrument};
 use tui::dialoguer::Confirm;
 use tui::dialoguer::theme::ColorfulTheme;
 use tui::pretty::autoprint_columns;
@@ -152,7 +152,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         event_type = "progress_start"
     );
 
-    runtime::block_on(client.cache_packages(&synced))?;
+    runtime::block_on(client.cache_packages(&synced).in_current_span())?;
 
     timing.fetch = instant.elapsed();
     info!(

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -7,7 +7,7 @@
 use std::time::{Duration, Instant};
 
 use thiserror::Error;
-use tracing::{debug, info, info_span, instrument};
+use tracing::{Instrument, debug, info, info_span, instrument};
 use tui::{
     dialoguer::{Confirm, theme::ColorfulTheme},
     pretty::autoprint_columns,
@@ -115,7 +115,7 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
     );
 
     // Cache packages
-    runtime::block_on(client.cache_packages(&missing))?;
+    runtime::block_on(client.cache_packages(&missing).in_current_span())?;
 
     timing.fetch = instant.elapsed();
     info!(


### PR DESCRIPTION
Add tracing to the `moss sync` command per #558 following the same pattern established in the `install` command #563.




