### PR TITLE
boulder/data: Modernize bolt macros

### DIFF
--- a/boulder/data/macros/actions/pgo.yaml
+++ b/boulder/data/macros/actions/pgo.yaml
@@ -40,7 +40,7 @@ actions:
         description: Apply bolt profile
         command: |
             boptim(){
-                llvm-bolt ${1}.orig -o ${1}.bolt -data=%(pgo_dir)/$(basename ${1}).fdata -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -split-strategy=cdsplit -plt=all -peepholes=all -split-eh -dyno-stats -icf=1 -use-gnu-stack -use-old-text -update-debug-sections ${2} ${3} ${4}
+                llvm-bolt ${1}.orig -o ${1}.bolt -data=%(pgo_dir)/$(basename ${1}).fdata -reorder-blocks=ext-tsp -reorder-functions=cdsort -split-functions -split-strategy=cdsplit -plt=all -peepholes=all -split-eh -dyno-stats -icf -use-old-text -update-debug-sections ${2} ${3} ${4}
                 cp ${1}.bolt ${1}
             }
             boptim

--- a/boulder/data/macros/actions/pgo.yaml
+++ b/boulder/data/macros/actions/pgo.yaml
@@ -24,7 +24,7 @@ actions:
             binstr(){
                 mv ${1} ${1}.orig
                 mkdir -p %(pgo_dir)/BOLT
-                llvm-bolt ${1}.orig -instrument --instrumentation-file=%(pgo_dir)/BOLT/$(basename ${1}) --instrumentation-file-append-pid ${2} ${3} ${4} -o ${1}
+                llvm-bolt ${1}.orig -instrument --instrumentation-file=%(pgo_dir)/BOLT/$(basename ${1}) --instrumentation-file-append-pid "${@:2}" -o ${1}
             }
             binstr
 
@@ -40,7 +40,7 @@ actions:
         description: Apply bolt profile
         command: |
             boptim(){
-                llvm-bolt ${1}.orig -o ${1}.bolt -data=%(pgo_dir)/$(basename ${1}).fdata -reorder-blocks=ext-tsp -reorder-functions=cdsort -split-functions -split-strategy=cdsplit -plt=all -peepholes=all -split-eh -dyno-stats -icf -use-old-text -update-debug-sections ${2} ${3} ${4}
+                llvm-bolt ${1}.orig -o ${1}.bolt -data=%(pgo_dir)/$(basename ${1}).fdata -reorder-blocks=ext-tsp -reorder-functions=cdsort -split-functions -split-strategy=cdsplit -plt=all -peepholes=all -split-eh -dyno-stats -icf -use-old-text -update-debug-sections "${@:2}"
                 cp ${1}.bolt ${1}
             }
             boptim


### PR DESCRIPTION
Update optimization flags:
- Replace deprecated hfsort+ with cdsort
- Replace deprecated -icf=1 with -icf usage
- Remove unneeded -use-gnu-stack option, recent binutils handle this fine https://forge.sourceware.org/binutils-gdb/binutils-gdb-mirror/commit/bbc969306f8d5fb6c7b636e25f6f8e278946ef23

Fix use of unbounded variables due to `set -u` being set, take an array instead.