### PR TITLE
boulder/data: Add LLVM CREL tuning flags

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -793,6 +793,13 @@ flags               :
     - relr:
         ld        : "-Wl,-z,pack-relative-relocs"
 
+    # Toggle crel (OFF)
+    - crel:
+        llvm:
+            c     : "-Wa,--crel,--allow-experimental-crel"
+            cxx   : "-Wa,--crel,--allow-experimental-crel"
+            f     : "-Wa,--crel,--allow-experimental-crel"
+
     # Toggle gnu2 TLS descriptors (ON)
     - tls-gnu:
         c         : "-mtls-dialect=gnu2"


### PR DESCRIPTION
https://maskray.me/blog/2024-03-09-a-compact-relocation-format-for-elf

Reduces the size of .o/.a files.

Currently, final executables are unaffected as LLD consumes the crel symbols until support for DT_CREL is added to ABI and GNU toolchain

The primary benefit is reducing size on disk for cached builds

Be aware that ld.bfd cannot handle CREL static .a files.

A simple lzip build:

CREL disabled:
308K    arg_parser.o
176K    decoder.o
140K    encoder_base.o
224K    encoder.o
132K    fast_encoder.o
112K    list.o
248K    lzip_index.o
608K    main.o

CREL enabled:
264K    arg_parser.o
152K    decoder.o
120K    encoder_base.o
196K    encoder.o
116K    fast_encoder.o
92K     list.o
212K    lzip_index.o
520K    main.o