### PR TITLE
crates/stone: Set JobSize to 16M

### DIFF
--- a/crates/stone/src/write/zstd.rs
+++ b/crates/stone/src/write/zstd.rs
@@ -82,6 +82,9 @@ impl Encoder {
         context
             .set_parameter(CParameter::WindowLog(31))
             .map_err(map_error_code)?;
+        context
+            .set_parameter(CParameter::JobSize(16777216))
+            .map_err(map_error_code)?;
         Ok(Self {
             context,
             output: vec![0; Context::out_size()],


### PR DESCRIPTION
For our configuration (lvl 18, Window Log 31) this provides a benefit in practically all cases over zstd's default of 32M