### PR TITLE
stone_script + boulder: Move eval_to_string() to context

### DIFF
--- a/boulder/src/build/script.rs
+++ b/boulder/src/build/script.rs
@@ -20,8 +20,8 @@ pub struct ScriptBundle {
 impl ScriptBundle {
     /// Compile a [ScriptBundle] from an [stone_script::Expr], using a specified [stone_script::ScriptEnv]
     pub fn build(env: ScriptEnv, prefix_expr: &Expr, expr: &Expr) -> Result<Self, Error> {
-        let prefix = stone_script::eval_to_string(&env, prefix_expr)?;
         let mut ctx = ScriptContext::new();
+        let prefix = ctx.eval_to_string(&env, prefix_expr)?;
         ctx.eval(&env, expr)?;
         let commands = ctx
             .flush_commands()

--- a/boulder/src/package.rs
+++ b/boulder/src/package.rs
@@ -147,7 +147,8 @@ fn resolve_packages(
 
     fn parse_content(env: &stone_script::ScriptEnv, source: &str) -> Result<String, Error> {
         let expr = stone_script::Expr::parse(source)?;
-        Ok(stone_script::eval_to_string(env, &expr)?)
+        let mut ctx = stone_script::ScriptContext::new();
+        Ok(ctx.eval_to_string(env, &expr)?)
     }
 
     let mut packages = BTreeMap::new();

--- a/crates/stone_script/src/context.rs
+++ b/crates/stone_script/src/context.rs
@@ -206,6 +206,41 @@ impl ScriptContext {
         Ok(())
     }
 
+    /// Evaluate an expression in this context, flushing its output as a string
+    ///
+    /// State accumulated in this context (such as dependencies) is preserved
+    /// across evaluations.
+    ///
+    /// ```rust
+    /// # use stone_script::{Definition, Expr, ScriptContext, ScriptEnv};
+    ///
+    /// let mut env = ScriptEnv::new();
+    /// env.add_definition("name", Definition {
+    ///     doc: None,
+    ///     value: Expr::parse("Seymour").unwrap(),
+    /// });
+    /// env.add_definition("item", Definition {
+    ///     doc: None,
+    ///     value: Expr::parse("fast food").unwrap(),
+    /// });
+    /// env.add_definition("adverb", Definition {
+    ///     doc: None,
+    ///     value: Expr::parse("Delightfully").unwrap(),
+    /// });
+    ///
+    /// let expr = Expr::parse("What if I would purchase %(item) and disguise it as my own cooking? %(adverb) devilish, %(name).").unwrap();
+    ///
+    /// let mut ctx = ScriptContext::new();
+    /// assert_eq!(
+    ///     ctx.eval_to_string(&env, &expr).unwrap(),
+    ///     "What if I would purchase fast food and disguise it as my own cooking? Delightfully devilish, Seymour.",
+    /// );
+    /// ```
+    pub fn eval_to_string(&mut self, env: &ScriptEnv, expr: &Expr) -> Result<String, Error> {
+        self.eval(env, expr)?;
+        Ok(self.flush_to_string())
+    }
+
     /// Flush all the emitted commands from the context
     pub fn flush_commands(&mut self) -> impl Iterator<Item = Command> {
         self.commands.drain(..)

--- a/crates/stone_script/src/lib.rs
+++ b/crates/stone_script/src/lib.rs
@@ -159,38 +159,6 @@ pub use env::{Action, Definition, ScriptEnv};
 pub use error::{Error, EvalError};
 pub use expr::{Expr, Fragment};
 
-/// Evaluate an [Expr] in a single-use context and extract the output as a string
-///
-/// ```rust
-/// # use stone_script::{Definition, Expr, ScriptEnv};
-///
-/// let mut env = ScriptEnv::new();
-/// env.add_definition("name", Definition {
-///     doc: None,
-///     value: Expr::parse("Seymour").unwrap(),
-/// });
-/// env.add_definition("item", Definition {
-///     doc: None,
-///     value: Expr::parse("fast food").unwrap(),
-/// });
-/// env.add_definition("adverb", Definition {
-///     doc: None,
-///     value: Expr::parse("Delightfully").unwrap(),
-/// });
-///
-/// let expr = Expr::parse("What if I would purchase %(item) and disguise it as my own cooking? %(adverb) devilish, %(name).").unwrap();
-///
-/// assert_eq!(
-///     stone_script::eval_to_string(&env, &expr).unwrap(),
-///     "What if I would purchase fast food and disguise it as my own cooking? Delightfully devilish, Seymour.",
-/// );
-/// ```
-pub fn eval_to_string(env: &ScriptEnv, expr: &Expr) -> Result<String, Error> {
-    let mut ctx = ScriptContext::new();
-    ctx.eval(env, expr)?;
-    Ok(ctx.flush_to_string())
-}
-
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This ensures any prefix actions coming from %scriptBase are picked up by the evaluator.

Previously, builddeps from macros specified in `environment` were not added for evaluation.