### PR TITLE
Cargo.toml: Drop unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,6 @@ dependencies = [
  "cbindgen",
  "libc",
  "stone",
- "strum",
 ]
 
 [[package]]
@@ -1972,7 +1971,6 @@ dependencies = [
  "arc-swap",
  "astr",
  "blsforme",
- "bytes",
  "camino",
  "chrono",
  "clap",
@@ -1999,7 +1997,6 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2",
  "similar",
  "snafu",
@@ -2011,7 +2008,6 @@ dependencies = [
  "tokio-util",
  "tools_buildinfo",
  "tracing",
- "tracing-subscriber",
  "tracing_common",
  "triggers",
  "tui",
@@ -3056,7 +3052,6 @@ name = "stone_recipe"
 version = "0.26.8"
 dependencies = [
  "kdl",
- "nom",
  "serde",
  "serde_yaml",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.94"
 [workspace.dependencies]
 astr.path = "crates/astr"
 blsforme = { git = "https://github.com/AerynOS/blsforme.git", rev = "55da60a60b6f883818fbd67c67557439787f2fce" }
-bytes = "1.6.0"
 camino = "1.1.10"
 chrono = "0.4.38"
 clap = { version = "4.5.8", features = ["derive", "string"] }
@@ -44,7 +43,6 @@ glob = "0.3.1"
 hex = "0.4.3"
 humansize = "2.1.3"
 indextree = "4.6.1"
-libsqlite3-sys = { version = "0.35.0", features = ["bundled"] }
 log = "0.4.22"
 nc = "0.9.7"
 nom = "7.1.3"

--- a/crates/stone_recipe/Cargo.toml
+++ b/crates/stone_recipe/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 
 [dependencies]
 kdl.workspace = true
-nom.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 snafu.workspace = true

--- a/libstone/Cargo.toml
+++ b/libstone/Cargo.toml
@@ -29,7 +29,6 @@ capi = []
 stone = { path = "../crates/stone", features = ["ffi"] }
 
 libc.workspace = true
-strum.workspace = true
 
 [build-dependencies]
 cbindgen.workspace = true

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -7,10 +7,6 @@ edition.workspace = true
 version.workspace = true
 rust-version.workspace = true
 
-[package.metadata.cargo-machete]
-# Needed for unixepoch() in src/db/state/migrations/2025-03-04-201550_init/up.sql
-ignored = ["libsqlite3-sys"]
-
 [features]
 testing = []
 
@@ -27,7 +23,6 @@ vfs = { path = "../crates/vfs" }
 
 astr.workspace = true
 blsforme.workspace = true
-bytes.workspace = true
 camino.workspace = true
 chrono.workspace = true
 clap_mangen.workspace = true
@@ -49,7 +44,6 @@ reqwest.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-serde_yaml.workspace = true
 similar.workspace = true
 sha2.workspace = true
 snafu.workspace = true
@@ -58,7 +52,6 @@ tokio.workspace = true
 tokio-util.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 url.workspace = true
 xxhash-rust.workspace = true
 zbus.workspace = true


### PR DESCRIPTION
Using `cargo machete`, I pruned unused dependencies.

We could potentially use `cargo machete` in CI for warnings, but for now let's prune these deps manually.