### PR TITLE
boulder: Enable cached incremental LTO support for GNU & LLVM toolchains

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -16,6 +16,9 @@ definitions:
     - workdir               : "%(_workdir)"
     - compiler_cache        : "%(_compiler_cache)"
     - scompiler_cache       : "%(_scompiler_cache)"
+    - compiler_lto_cache    : "%(_compiler_lto_cache)"
+    - ltoincremental        : "%(_ltoincremental)"
+    - rustltoincremental    : "%(_rustltoincremental)"
     - sourcedateepoch       : "%(_sourcedateepoch)"
     - compiler_go_cache     : "%(_compiler_go_cache)"
     - compiler_go_mod_cache : "%(_compiler_go_mod_cache)"
@@ -103,6 +106,7 @@ definitions:
     - cargocachedir  : "%(compiler_cargo_cache)"
     - zigcachedir    : "%(compiler_zig_cache)"
     - sccachedir     : "%(scompiler_cache)"
+    - ltocachedir    : "%(compiler_lto_cache)"
     - pkgconfigpath  : "%(libdir)/pkgconfig:/usr/share/pkgconfig"
 
 actions              :
@@ -568,10 +572,10 @@ flags               :
     - lto-full:
         rust      : "-C lto=fat -C linker-plugin-lto -C embed-bitcode=yes"
         gnu:
-            c         : "-flto=%(jobs) -flto-partition=one"
-            cxx       : "-flto=%(jobs) -flto-partition=one"
-            f         : "-flto=%(jobs) -flto-partition=one"
-            ld        : "-flto=%(jobs) -flto-partition=one"
+            c         : "-flto=%(jobs) -flto-partition=one %(ltoincremental)"
+            cxx       : "-flto=%(jobs) -flto-partition=one %(ltoincremental)"
+            f         : "-flto=%(jobs) -flto-partition=one %(ltoincremental)"
+            ld        : "-flto=%(jobs) -flto-partition=one %(ltoincremental)"
         llvm:
             c         : "-flto=full"
             cxx       : "-flto=full"
@@ -581,18 +585,18 @@ flags               :
 
     # Enable Thin-LTO optimisations (ON)
     - lto-thin:
-        rust      : "-C lto=thin -C linker-plugin-lto -C embed-bitcode=yes"
+        rust      : "-C lto=thin -C linker-plugin-lto -C embed-bitcode=yes %(rustltoincremental)"
         gnu:
-            c         : "-flto=%(jobs)"
-            cxx       : "-flto=%(jobs)"
-            f         : "-flto=%(jobs)"
-            ld        : "-flto=%(jobs)"
+            c         : "-flto=%(jobs) %(ltoincremental)"
+            cxx       : "-flto=%(jobs) %(ltoincremental)"
+            f         : "-flto=%(jobs) %(ltoincremental)"
+            ld        : "-flto=%(jobs) %(ltoincremental)"
         llvm:
             c         : "-flto=thin"
             cxx       : "-flto=thin"
             f         : "-flto=thin"
             d         : "-flto=thin"
-            ld        : "-flto=thin"
+            ld        : "-flto=thin %(ltoincremental)"
 
     # Enable LTOextra optimisations (OFF)
     - ltoextra-full:

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -142,12 +142,27 @@ impl Phase {
             env.add_builtin_string("compiler_cargo_cache", "/mason/cargocache");
             env.add_builtin_string("compiler_zig_cache", "/mason/zigcache");
             env.add_builtin_string("rustc_wrapper", "/usr/bin/sccache");
+            env.add_builtin_string("compiler_lto_cache", "/mason/ltocache");
+            env.add_builtin(
+                "ltoincremental",
+                stone_script::Expr::parse(match recipe.parsed.options.toolchain {
+                    Toolchain::Llvm => "-Wl,--thinlto-cache-dir=%(ltocachedir)",
+                    Toolchain::Gnu => "-flto-incremental=%(ltocachedir)",
+                })?,
+            );
+            env.add_builtin(
+                "rustltoincremental",
+                stone_script::Expr::parse("-C link-args=-Wl,--thinlto-cache-dir=%(ltocachedir)")?,
+            );
         } else {
             env.add_builtin_string("compiler_go_cache", "");
             env.add_builtin_string("compiler_go_mod_cache", "");
             env.add_builtin_string("compiler_cargo_cache", "");
             env.add_builtin_string("compiler_zig_cache", "");
             env.add_builtin_string("rustc_wrapper", "");
+            env.add_builtin_string("compiler_lto_cache", "");
+            env.add_builtin_string("ltoincremental", "");
+            env.add_builtin_string("rustltoincremental", "");
         }
 
         /* Set the relevant compilers */

--- a/boulder/src/container.rs
+++ b/boulder/src/container.rs
@@ -26,6 +26,7 @@ where
     let cargocache = paths.cargocache();
     let zigcache = paths.zigcache();
     let rustc_wrapper = paths.sccache();
+    let ltocache = paths.ltocache();
     let recipe = paths.recipe();
     let ccache_conf = paths.ccache_config();
 
@@ -42,6 +43,7 @@ where
         .bind_rw(&cargocache.host, &cargocache.guest)
         .bind_rw(&zigcache.host, &zigcache.guest)
         .bind_rw(&rustc_wrapper.host, &rustc_wrapper.guest)
+        .bind_rw(&ltocache.host, &ltocache.guest)
         .bind_ro(&recipe.host, &recipe.guest)
         .bind_ro_if_exists(&ccache_conf.host, &ccache_conf.guest);
 

--- a/boulder/src/paths.rs
+++ b/boulder/src/paths.rs
@@ -61,6 +61,7 @@ impl Paths {
         util::ensure_dir_exists(&job.cargocache().host)?;
         util::ensure_dir_exists(&job.zigcache().host)?;
         util::ensure_dir_exists(&job.sccache().host)?;
+        util::ensure_dir_exists(&job.ltocache().host)?;
         util::ensure_dir_exists(&job.upstreams().host)?;
 
         Ok(job)
@@ -134,6 +135,13 @@ impl Paths {
         Mapping {
             host: self.host_root.join("sccache"),
             guest: self.guest_root.join("sccache"),
+        }
+    }
+
+    pub fn ltocache(&self) -> Mapping {
+        Mapping {
+            host: self.host_root.join("ltocache"),
+            guest: self.guest_root.join("ltocache"),
         }
     }
 


### PR DESCRIPTION
Cache LTO artefacts by default when ccache is enabled. Note that LLVM's fat LTO is not supported. This can compliment ccache/sccache.

Benchmarks 

(sccache enabled):
starship (rust, thin-lto):
no LTO cache, no sccache       : 2m37.31s
LTO uncached, sccache disabled : 2m36.88s
LTO cached, sccache disabled   : 1m58.47s
LTO cached, sccache uncached   : 2m11.85s
LTO cached, sccache cached:    : 12.70s
no LTO cache, sccache uncached : 3m03.27s
no LTO cache, sscache cached   : 1m02.44s

(ccache disabled):
zlib-ng (llvm, thin-lto):
Uncached (warm first run) : 3.21s
Cached (second run)       : 2.51s

emacs (gcc, lto):
Uncached (warm first run) : 4m04.47s
Cached (second run)       : 3m45.09s