### PR TITLE
Optimize block_on with thread-local runtime

### DIFF
--- a/moss/src/runtime.rs
+++ b/moss/src/runtime.rs
@@ -1,25 +1,37 @@
 // SPDX-FileCopyrightText: 2024 AerynOS Developers
 // SPDX-License-Identifier: MPL-2.0
+// idk what to do with the comment above, so i will just keep it like this
 
+use std::cell::RefCell;
 use std::future::Future;
+use tokio::runtime::Runtime;
 
-use tokio::runtime::{self, Handle};
+thread_local! {
+    static TEMP_RT: RefCell<Option<Runtime>> = const { RefCell::new(None) };
+}
 
-/// Run the provided future on a single use runtime that
-/// is dropped before returning the completed task
+/// Run the provide futuer on a thred local cached runtim to elliminate
+/// the alocation and distruction overhed off per call runtimes.
 pub fn block_on<T, F>(task: F) -> T
 where
     F: Future<Output = T>,
 {
-    let temp_rt = runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("temp runtime");
-    temp_rt.block_on(task)
+    TEMP_RT.with(|rt| {
+        let mut slot = rt.borrow_mut();
+        let runtime = slot.get_or_insert_with(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build thread-local runtime")
+        });
+        runtime.block_on(task)
+    })
 }
 
-/// Runs the provided function on an executor dedicated to blocking.
+/// Run the provide function on tokios dedikated blockin thread pool.
+#[inline]
 pub async fn unblock<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
-    let handle = Handle::current();
-    handle.spawn_blocking(f).await.expect("spawn blocking")
+    tokio::task::spawn_blocking(f)
+        .await
+        .expect("spawn_blocking task panicked")
 }


### PR DESCRIPTION
Refactor block_on to use thread-local cached runtime and improve performance by eliminating allocation overhead. Added the #[inline] attribute to unblock to allow the compiler to inline the function across crate boundaries. Replaced creating and dropping a new runtime::Builder.  that is mostly all i did.