### PR TITLE
boulder: Disable forced 128bit vector width by default

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -172,7 +172,6 @@ actions              :
 
 defaultTuningGroups :
     - asneeded
-    - avxwidth
     - base
     - bindnow
     - build-id
@@ -744,7 +743,7 @@ flags               :
             c         : "-fno-direct-access-external-data"
             cxx       : "-fno-direct-access-external-data"
 
-    # Prefer 128-bit vector width (ON)
+    # Prefer 128-bit vector width (OFF)
     - avxwidth-128:
         c         : "-mprefer-vector-width=128"
         cxx       : "-mprefer-vector-width=128"


### PR DESCRIPTION
Allow clang/gcc cost models to automatically choose whatever width they feel is appropriate for auto-vectorization cases.

The toolchains are mature enough to automatically emit `vzeroupper` instructions to avoid the large 256bit -> 128bit latency cost.

This will improve performance in some cases where the toolchain deicides that bigger-width vectorization is worth it.